### PR TITLE
[Requirements] implementing requirements to be enforced via disabling of the play button, and showing information to the player in the level details

### DIFF
--- a/assets/colors.bsml
+++ b/assets/colors.bsml
@@ -1,0 +1,16 @@
+<modal id='_colorsOptionsModal' anchor-pos-x='-5' anchor-pos-y='5'
+    clickerino-offerino-closerino='false' size-delta-x='85' size-delta-y='30'
+    xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+    xsi:noNamespaceSchemaLocation='https://raw.githubusercontent.com/RedBrumbler/Quest-BSML-Docs/gh-pages/schema.xsd'>
+    <vertical
+        horizontal-fit='PreferredSize'
+        pref-width='80'>
+        <checkbox-setting text='Allow Custom Song Note Colors' value='customSongNoteColors' hover-hint='Allow Custom Songs to override note colors' apply-on-change='true'/>
+        <checkbox-setting text='Allow Custom Song Obstacle Colors' value='customSongObstacleColors' hover-hint='Allow Custom Songs to override wall colors' apply-on-change='true'/>
+        <checkbox-setting text='Allow Custom Song Environment Colors' value='customSongEnvironmentColors' hover-hint='Allow Custom Songs to override light colors' apply-on-change='true'/>
+        <horizontal spacing='-5'>
+            <text text='Selected Custom Song&#39;s Colors' italics='true' />
+            <background id='_selectedColorBG'/>
+        </horizontal>
+    </vertical>
+</modal>

--- a/assets/requirements.bsml
+++ b/assets/requirements.bsml
@@ -1,0 +1,23 @@
+<modal id='_requirementModal'
+    clickerino-offerino-closerino='true'
+    anchor-pos-x='0'
+    anchor-pos-y='10'
+    size-delta-x='65'
+    size-delta-y='65'
+    move-to-center='false'
+    xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+    xsi:noNamespaceSchemaLocation='https://raw.githubusercontent.com/RedBrumbler/Quest-BSML-Docs/gh-pages/schema.xsd'>
+    <vertical
+        horizontal-fit='PreferredSize'
+        vertical-fit='PreferredSize'
+        anchor-pos-x='-3'
+        size-delta-y='0'>
+        <list id='_listTableData'
+            data='requirementsCells'
+            select-cell='RequirementCellSelected'
+            pref-height='55'
+            pref-width='55'
+            show-scrollbar='true'
+            stick-scrolling='true'/>
+    </vertical>
+</modal>

--- a/include/UI/ColorsOptions.hpp
+++ b/include/UI/ColorsOptions.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "custom-types/shared/macros.hpp"
+#include "System/Object.hpp"
+#include "CustomJSONData.hpp"
+#include "GlobalNamespace/StandardLevelDetailViewController.hpp"
+#include "GlobalNamespace/ColorSchemeView.hpp"
+#include "bsml/shared/BSML/Components/Settings/ToggleSetting.hpp"
+#include "bsml/shared/BSML/Components/ModalView.hpp"
+
+DECLARE_CLASS_CODEGEN(SongCore::UI, ColorsOptions, System::Object,
+        DECLARE_CTOR(ctor, GlobalNamespace::StandardLevelDetailViewController* levelDetailViewController);
+
+        DECLARE_INSTANCE_FIELD_PRIVATE(GlobalNamespace::StandardLevelDetailViewController*, _levelDetailViewController);
+        DECLARE_INSTANCE_FIELD_PRIVATE(GlobalNamespace::ColorSchemeView*, _colorSchemeView);
+        DECLARE_INSTANCE_FIELD_PRIVATE(BSML::ModalView*, _colorsOptionsModal);
+        DECLARE_INSTANCE_FIELD_PRIVATE(UnityEngine::RectTransform*, _selectedColorBG);
+        DECLARE_INSTANCE_FIELD_PRIVATE(UnityEngine::Color, _voidColor);
+        DECLARE_INSTANCE_FIELD_PRIVATE(System::Action*, _modalHideAction);
+
+        DECLARE_INSTANCE_METHOD(void, PostParse);
+
+        DECLARE_INSTANCE_METHOD(bool, get_customSongNoteColors);
+        DECLARE_INSTANCE_METHOD(void, set_customSongNoteColors, bool value);
+        DECLARE_INSTANCE_METHOD(bool, get_customSongObstacleColors);
+        DECLARE_INSTANCE_METHOD(void, set_customSongObstacleColors, bool value);
+        DECLARE_INSTANCE_METHOD(bool, get_customSongEnvironmentColors);
+        DECLARE_INSTANCE_METHOD(void, set_customSongEnvironmentColors, bool value);
+        DECLARE_INSTANCE_METHOD(void, Dismiss);
+    public:
+        void ShowColors(CustomJSONData::CustomLevelInfoSaveData::BasicCustomDifficultyBeatmapDetails const& details);
+        std::function<void()> onModalHide;
+    private:
+        void SetColors(CustomJSONData::CustomLevelInfoSaveData::BasicCustomDifficultyBeatmapDetails::CustomColors const& colors);
+)

--- a/include/UI/IconCache.hpp
+++ b/include/UI/IconCache.hpp
@@ -1,0 +1,74 @@
+#pragma once
+
+#include "custom-types/shared/macros.hpp"
+#include "UnityEngine/Sprite.hpp"
+#include "System/Object.hpp"
+#include "Zenject/IInitializable.hpp"
+#include "System/IDisposable.hpp"
+#include "System/Collections/Generic/Dictionary_2.hpp"
+
+DECLARE_CLASS_CODEGEN_INTERFACES(SongCore::UI, IconCache, System::Object, classof(System::IDisposable*),
+    DECLARE_CTOR(ctor);
+    DECLARE_OVERRIDE_METHOD_MATCH(void, Dispose, &System::IDisposable::Dispose);
+
+    DECLARE_INSTANCE_FIELD_PRIVATE(UnityEngine::Sprite*, _colorsIcon);
+    DECLARE_INSTANCE_FIELD_PRIVATE(UnityEngine::Sprite*, _environmentIcon);
+    DECLARE_INSTANCE_FIELD_PRIVATE(UnityEngine::Sprite*, _extraDiffsIcon);
+    DECLARE_INSTANCE_FIELD_PRIVATE(UnityEngine::Sprite*, _folderIcon);
+    DECLARE_INSTANCE_FIELD_PRIVATE(UnityEngine::Sprite*, _haveReqIcon);
+    DECLARE_INSTANCE_FIELD_PRIVATE(UnityEngine::Sprite*, _infoIcon);
+    DECLARE_INSTANCE_FIELD_PRIVATE(UnityEngine::Sprite*, _oneSaberIcon);
+    DECLARE_INSTANCE_FIELD_PRIVATE(UnityEngine::Sprite*, _missingReqIcon);
+    DECLARE_INSTANCE_FIELD_PRIVATE(UnityEngine::Sprite*, _standardIcon);
+    DECLARE_INSTANCE_FIELD_PRIVATE(UnityEngine::Sprite*, _warningIcon);
+    DECLARE_INSTANCE_FIELD_PRIVATE(UnityEngine::Sprite*, _haveSuggestionIcon);
+    DECLARE_INSTANCE_FIELD_PRIVATE(UnityEngine::Sprite*, _missingSuggestionIcon);
+
+    using IconDict = System::Collections::Generic::Dictionary_2<StringW, UnityEngine::Sprite*>;
+    DECLARE_INSTANCE_FIELD_PRIVATE(IconDict*, _pathIcons);
+    public:
+        UnityEngine::Sprite* GetIconForPath(std::filesystem::path const& path);
+
+        UnityEngine::Sprite* GetColorsIcon();
+        __declspec(property(get=GetColorsIcon)) UnityEngine::Sprite* ColorsIcon;
+
+        UnityEngine::Sprite* GetEnvironmentIcon();
+        __declspec(property(get=GetEnvironmentIcon)) UnityEngine::Sprite* EnvironmentIcon;
+
+        UnityEngine::Sprite* GetExtraDiffsIcon();
+        __declspec(property(get=GetExtraDiffsIcon)) UnityEngine::Sprite* ExtraDiffsIcon;
+
+        UnityEngine::Sprite* GetFolderIcon();
+        __declspec(property(get=GetFolderIcon)) UnityEngine::Sprite* FolderIcon;
+
+        UnityEngine::Sprite* GetHaveReqIcon();
+        __declspec(property(get=GetHaveReqIcon)) UnityEngine::Sprite* HaveReqIcon;
+
+        UnityEngine::Sprite* GetInfoIcon();
+        __declspec(property(get=GetInfoIcon)) UnityEngine::Sprite* InfoIcon;
+
+        UnityEngine::Sprite* GetOneSaberIcon();
+        __declspec(property(get=GetOneSaberIcon)) UnityEngine::Sprite* OneSaberIcon;
+
+        UnityEngine::Sprite* GetMissingReqIcon();
+        __declspec(property(get=GetMissingReqIcon)) UnityEngine::Sprite* MissingReqIcon;
+
+        UnityEngine::Sprite* GetStandardIcon();
+        __declspec(property(get=GetStandardIcon)) UnityEngine::Sprite* StandardIcon;
+
+        UnityEngine::Sprite* GetWarningIcon();
+        __declspec(property(get=GetWarningIcon)) UnityEngine::Sprite* WarningIcon;
+
+        UnityEngine::Sprite* GetHaveSuggestionIcon();
+        __declspec(property(get=GetHaveSuggestionIcon)) UnityEngine::Sprite* HaveSuggestionIcon;
+
+        UnityEngine::Sprite* GetMissingSuggestionIcon();
+        __declspec(property(get=GetMissingSuggestionIcon)) UnityEngine::Sprite* MissingSuggestionIcon;
+
+    private:
+        static constexpr size_t MAX_ICON_CACHE_COUNT = 50;
+        /// @brief keeps track of the last used icons, and if the cache has too many used icons, the least used will be removed
+        std::list<std::filesystem::path> _lastUsedIcons;
+
+        void PathWasUsed(std::filesystem::path const& path);
+)

--- a/include/UI/PlayButtonsUpdater.hpp
+++ b/include/UI/PlayButtonsUpdater.hpp
@@ -19,9 +19,8 @@
 #include "GlobalNamespace/IDifficultyBeatmap.hpp"
 
 DECLARE_CLASS_CODEGEN_INTERFACES(SongCore::UI, PlayButtonsUpdater, System::Object, std::vector<Il2CppClass*>({classof(Zenject::IInitializable*), classof(System::IDisposable*)}),
-    DECLARE_CTOR(ctor, GlobalNamespace::StandardLevelDetailViewController* levelDetailViewController, GlobalNamespace::LevelSelectionNavigationController* levelSelectionNavigationController, PlayButtonInteractable* playButtonInteractable, Capabilities* capabilities);
+    DECLARE_CTOR(ctor, GlobalNamespace::StandardLevelDetailViewController* levelDetailViewController, PlayButtonInteractable* playButtonInteractable, Capabilities* capabilities);
     DECLARE_INSTANCE_FIELD_PRIVATE(GlobalNamespace::StandardLevelDetailViewController*, _levelDetailViewController);
-    DECLARE_INSTANCE_FIELD_PRIVATE(GlobalNamespace::LevelSelectionNavigationController*, _levelSelectionNavigationController);
     DECLARE_INSTANCE_FIELD_PRIVATE(PlayButtonInteractable*, _playButtonInteractable);
     DECLARE_INSTANCE_FIELD_PRIVATE(Capabilities*, _capabilities);
 

--- a/include/UI/PlayButtonsUpdater.hpp
+++ b/include/UI/PlayButtonsUpdater.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "CustomJSONData.hpp"
+#include "custom-types/shared/macros.hpp"
+#include "System/Object.hpp"
+#include "Zenject/IInitializable.hpp"
+#include "System/IDisposable.hpp"
+#include "UnityEngine/UI/Button.hpp"
+
+#include "SongLoader/RuntimeSongLoader.hpp"
+#include "PlayButtonInteractable.hpp"
+#include "Capabilities.hpp"
+#include "CustomJSONData.hpp"
+
+#include "GlobalNamespace/StandardLevelDetailViewController.hpp"
+#include "GlobalNamespace/StandardLevelDetailView.hpp"
+#include "GlobalNamespace/LevelSelectionNavigationController.hpp"
+#include "GlobalNamespace/CustomBeatmapLevel.hpp"
+#include "GlobalNamespace/IDifficultyBeatmap.hpp"
+
+DECLARE_CLASS_CODEGEN_INTERFACES(SongCore::UI, PlayButtonsUpdater, System::Object, std::vector<Il2CppClass*>({classof(Zenject::IInitializable*), classof(System::IDisposable*)}),
+    DECLARE_CTOR(ctor, GlobalNamespace::StandardLevelDetailViewController* levelDetailViewController, GlobalNamespace::LevelSelectionNavigationController* levelSelectionNavigationController, PlayButtonInteractable* playButtonInteractable, Capabilities* capabilities);
+    DECLARE_INSTANCE_FIELD_PRIVATE(GlobalNamespace::StandardLevelDetailViewController*, _levelDetailViewController);
+    DECLARE_INSTANCE_FIELD_PRIVATE(GlobalNamespace::LevelSelectionNavigationController*, _levelSelectionNavigationController);
+    DECLARE_INSTANCE_FIELD_PRIVATE(PlayButtonInteractable*, _playButtonInteractable);
+    DECLARE_INSTANCE_FIELD_PRIVATE(Capabilities*, _capabilities);
+
+    DECLARE_INSTANCE_FIELD_PRIVATE(GlobalNamespace::CustomBeatmapLevel*, _lastSelectedCustomLevel);
+    DECLARE_INSTANCE_FIELD_PRIVATE(GlobalNamespace::IDifficultyBeatmap*, _lastSelectedDifficultyBeatmap);
+
+    DECLARE_INSTANCE_FIELD_PRIVATE(UnityEngine::UI::Button*, _playButton);
+    DECLARE_INSTANCE_FIELD_PRIVATE(UnityEngine::UI::Button*, _practiceButton);
+
+    using ChangeDifficultyBeatmapAction = System::Action_2<UnityW<GlobalNamespace::StandardLevelDetailViewController>, GlobalNamespace::IDifficultyBeatmap*>;
+    using ChangeContentAction = System::Action_2<UnityW<GlobalNamespace::StandardLevelDetailViewController>, GlobalNamespace::StandardLevelDetailViewController::ContentType>;
+    DECLARE_INSTANCE_FIELD_PRIVATE(ChangeDifficultyBeatmapAction*, _changeDifficultyBeatmapAction);
+    DECLARE_INSTANCE_FIELD_PRIVATE(ChangeContentAction*, _changeContentAction);
+
+    DECLARE_OVERRIDE_METHOD_MATCH(void, Initialize, &Zenject::IInitializable::Initialize);
+    DECLARE_OVERRIDE_METHOD_MATCH(void, Dispose, &System::IDisposable::Dispose);
+
+    private:
+        void LevelDetailContentChanged(GlobalNamespace::StandardLevelDetailViewController* levelDetailViewController, GlobalNamespace::StandardLevelDetailViewController::ContentType contentType);
+        void BeatmapLevelSelected(GlobalNamespace::StandardLevelDetailViewController* levelDetailViewController, GlobalNamespace::IDifficultyBeatmap* selectedBeatmap);
+
+        void HandleVanillaLevelWasSelected(GlobalNamespace::IBeatmapLevel* level, GlobalNamespace::IDifficultyBeatmap* difficultyBeatmap);
+        void HandleCustomLevelWasSelected(GlobalNamespace::CustomBeatmapLevel* level, GlobalNamespace::IDifficultyBeatmap* difficultyBeatmap);
+
+        bool IsPlayerAllowedToStart();
+        void UpdatePlayButtonsState();
+
+        /// @brief whether there are any disabling mod infos
+        bool _anyDisablingModInfos;
+        void HandleDisablingModInfosChanged(std::span<PlayButtonInteractable::PlayButtonDisablingModInfo const> disablingModInfos);
+)

--- a/include/UI/RequirementsListManager.hpp
+++ b/include/UI/RequirementsListManager.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "custom-types/shared/macros.hpp"
+#include "Zenject/IInitializable.hpp"
+#include "System/IDisposable.hpp"
+
+#include "UnityEngine/UI/Button.hpp"
+#include "UnityEngine/GameObject.hpp"
+#include "GlobalNamespace/StandardLevelDetailViewController.hpp"
+#include "GlobalNamespace/CustomBeatmapLevel.hpp"
+#include "GlobalNamespace/IDifficultyBeatmap.hpp"
+#include "GlobalNamespace/IBeatmapLevel.hpp"
+
+#include "Capabilities.hpp"
+#include "IconCache.hpp"
+#include "ColorsOptions.hpp"
+
+#include "bsml/shared/BSML/Components/CustomListTableData.hpp"
+#include "bsml/shared/BSML/Components/ModalView.hpp"
+
+DECLARE_CLASS_CODEGEN_INTERFACES(SongCore::UI, RequirementsListManager, System::Object, std::vector<Il2CppClass*>({classof(Zenject::IInitializable*), classof(System::IDisposable*)}),
+    DECLARE_CTOR(ctor, GlobalNamespace::StandardLevelDetailViewController* levelDetailViewController, ColorsOptions* colorsOptions, Capabilities* capabilities, IconCache* _iconCache);
+
+    DECLARE_INSTANCE_FIELD_PRIVATE(GlobalNamespace::StandardLevelDetailViewController*, _levelDetailViewController);
+    DECLARE_INSTANCE_FIELD_PRIVATE(ColorsOptions*, _colorsOptions);
+    DECLARE_INSTANCE_FIELD_PRIVATE(Capabilities*, _capabilities);
+    DECLARE_INSTANCE_FIELD_PRIVATE(IconCache*, _iconCache);
+
+    DECLARE_INSTANCE_FIELD_PRIVATE(GlobalNamespace::CustomBeatmapLevel*, _lastSelectedCustomLevel);
+    DECLARE_INSTANCE_FIELD_PRIVATE(GlobalNamespace::IDifficultyBeatmap*, _lastSelectedDifficultyBeatmap);
+
+    DECLARE_INSTANCE_FIELD_PRIVATE(UnityEngine::UI::Button*, _requirementButton);
+    DECLARE_INSTANCE_FIELD_PRIVATE(BSML::CustomListTableData*, _listTableData);
+    DECLARE_INSTANCE_FIELD_PRIVATE(BSML::ModalView*, _requirementModal);
+    DECLARE_INSTANCE_FIELD_PRIVATE(System::Action*, _showColorsOnModalHideAction);
+    DECLARE_INSTANCE_FIELD_PRIVATE(ListW<BSML::CustomCellInfo*>, _requirementsCells);
+    DECLARE_INSTANCE_FIELD_PRIVATE(ListW<BSML::CustomCellInfo*>, _unusedRequirementCells);
+
+    using ChangeDifficultyBeatmapAction = System::Action_2<UnityW<GlobalNamespace::StandardLevelDetailViewController>, GlobalNamespace::IDifficultyBeatmap*>;
+    using ChangeContentAction = System::Action_2<UnityW<GlobalNamespace::StandardLevelDetailViewController>, GlobalNamespace::StandardLevelDetailViewController::ContentType>;
+    DECLARE_INSTANCE_FIELD_PRIVATE(ChangeDifficultyBeatmapAction*, _changeDifficultyBeatmapAction);
+    DECLARE_INSTANCE_FIELD_PRIVATE(ChangeContentAction*, _changeContentAction);
+
+    DECLARE_OVERRIDE_METHOD_MATCH(void, Initialize, &Zenject::IInitializable::Initialize);
+    DECLARE_OVERRIDE_METHOD_MATCH(void, Dispose, &System::IDisposable::Dispose);
+
+    DECLARE_INSTANCE_METHOD(void, ShowRequirements);
+
+    DECLARE_INSTANCE_METHOD(void, RequirementCellSelected, HMUI::TableView* tableView, int cellIndex);
+    DECLARE_INSTANCE_METHOD(ListW<BSML::CustomCellInfo*>, get_requirementsCells);
+    private:
+        void LevelDetailContentChanged(GlobalNamespace::StandardLevelDetailViewController* levelDetailViewController, GlobalNamespace::StandardLevelDetailViewController::ContentType contentType);
+        void BeatmapLevelSelected(GlobalNamespace::StandardLevelDetailViewController* levelDetailViewController, GlobalNamespace::IDifficultyBeatmap* selectedBeatmap);
+
+        void HandleVanillaLevelWasSelected(GlobalNamespace::IBeatmapLevel* level, GlobalNamespace::IDifficultyBeatmap* difficultyBeatmap);
+        void HandleCustomLevelWasSelected(GlobalNamespace::CustomBeatmapLevel* level, GlobalNamespace::IDifficultyBeatmap* difficultyBeatmap);
+
+        void ShowColorsOptions();
+        void UpdateRequirementButton();
+        void SetRequirementButtonActive(bool active);
+
+        BSML::CustomCellInfo* GetCellInfo();
+        void ClearRequirementCells();
+        void UpdateRequirementCells();
+
+)

--- a/include/assets.hpp
+++ b/include/assets.hpp
@@ -18,3 +18,5 @@ DECLARE_FILE(_binary_Resources_Warning_png, Assets::Resources, Warning_png);
 DECLARE_FILE(_binary_Resources_YellowCheck_png, Assets::Resources, YellowCheck_png);
 DECLARE_FILE(_binary_Resources_YellowX_png, Assets::Resources, YellowX_png);
 DECLARE_FILE(_binary_Resources_pixel_png, Assets::Resources, pixel_png);
+DECLARE_FILE(_binary_colors_bsml, Assets, colors_bsml);
+DECLARE_FILE(_binary_requirements_bsml, Assets, requirements_bsml);

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <filesystem>
+#include <vector>
 
 struct Config {
     /// @brief whether to apply note colors from diffs

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -3,6 +3,16 @@
 #include <filesystem>
 
 struct Config {
+    /// @brief whether to apply note colors from diffs
+    bool customSongNoteColors = true;
+    /// @brief whether to apply obstacle colors from diffs
+    bool customSongObstacleColors = true;
+    /// @brief whether to apply environment colors from diffs
+    bool customSongEnvironmentColors = true;
+
+    /// @brief whether the saber count override should be honored
+    bool disableOneSaberOverride = false;
+
     /// @brief path to the preferred folder where to store songs. This is exposed to people consuming the api as a getter
     std::filesystem::path PreferredCustomLevelPath = "/sdcard/ModData/com.beatgames.beatsaber/Mods/SongCore/CustomLevels";
     /// @brief multiple paths to folders to load songs from, in case user has multiple folders. Not exposed

--- a/qpm.shared.json
+++ b/qpm.shared.json
@@ -1,5 +1,6 @@
 {
   "config": {
+    "version": "0.1.0",
     "sharedDir": "shared",
     "dependenciesDir": "extern",
     "info": {
@@ -11,10 +12,31 @@
         "overrideSoName": "libsongcore.so"
       }
     },
+    "workspace": {
+      "scripts": {
+        "build": [
+          "pwsh ./scripts/build.ps1"
+        ],
+        "clean": [
+          "pwsh ./scripts/build.ps1 -clean"
+        ],
+        "copy": [
+          "pwsh ./scripts/copy.ps1"
+        ],
+        "qmod": [
+          "pwsh ./scripts/build.ps1",
+          "qpm qmod build",
+          "pwsh ./scripts/createqmod.ps1 SongCore"
+        ],
+        "restart": [
+          "pwsh ./scripts/restart-game.ps1"
+        ]
+      }
+    },
     "dependencies": [
       {
         "id": "beatsaber-hook",
-        "versionRange": "=5.0.9",
+        "versionRange": "^5.0.9",
         "additionalData": {
           "extraFiles": [
             "src/inline-hook"
@@ -61,28 +83,7 @@
         "versionRange": "^8.5.0",
         "additionalData": {}
       }
-    ],
-    "workspace": {
-      "scripts": {
-        "build": [
-          "pwsh ./scripts/build.ps1"
-        ],
-        "clean": [
-          "pwsh ./scripts/build.ps1 -clean"
-        ],
-        "copy": [
-          "pwsh ./scripts/copy.ps1"
-        ],
-        "qmod": [
-          "pwsh ./scripts/build.ps1",
-          "qpm qmod build",
-          "pwsh ./scripts/createqmod.ps1 SongCore"
-        ],
-        "restart": [
-          "pwsh ./scripts/restart-game.ps1"
-        ]
-      }
-    }
+    ]
   },
   "restoredDependencies": [
     {
@@ -136,7 +137,6 @@
         "versionRange": "=8.5.0",
         "additionalData": {
           "staticLinking": true,
-          "useRelease": true,
           "soLink": "https://github.com/darknight1050/cryptopp-qpm/releases/download/v8.5.0/libcryptopp.a",
           "overrideSoName": "libcryptopp.a",
           "branchName": "version-v8.5.0"

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -25,7 +25,8 @@ if ($clean.IsPresent) {
 
 if (($clean.IsPresent) -or (-not (Test-Path -Path "build"))) {
     new-item -Path build -ItemType Directory
-} 
+}
 
-& cmake -G "Ninja" -DCMAKE_BUILD_TYPE="RelWithDebInfo" -B build -Wno-dev 
+& cmake -G "Ninja" -DCMAKE_BUILD_TYPE="RelWithDebInfo" -B build -Wno-dev
 & cmake --build ./build
+return $LastExitCode

--- a/scripts/createqmod.ps1
+++ b/scripts/createqmod.ps1
@@ -17,7 +17,6 @@ if ($help -eq $true) {
 
 $mod = "./mod.json"
 
-& $PSScriptRoot/validate-modjson.ps1
 if ($LASTEXITCODE -ne 0) {
     exit $LASTEXITCODE
 }

--- a/shared/CustomJSONData.hpp
+++ b/shared/CustomJSONData.hpp
@@ -45,19 +45,6 @@ public:
 
 	/// @brief struct providing basic information about a difficulty beatmap (characteristic + difficulty)
 	struct BasicCustomDifficultyBeatmapDetails {
-		/// @brief struct describing a contributor entry
-		struct Contributor {
-			/// @brief name of this contributor
-			std::string name;
-			/// @brief what did they do?
-			std::string role;
-			/// @brief path to the icon to display for this contributor
-			std::filesystem::path iconPath;
-
-			/// @brief deserializer method
-			/// @return whether deserialization was succesful
-			bool Deserialize(ValueUTF16 const& value);
-		};
 		struct CustomColors {
 			std::optional<UnityEngine::Color> colorLeft;
 			std::optional<UnityEngine::Color> colorRight;
@@ -88,21 +75,18 @@ public:
 		/// @brief information for this beatmap
 		std::vector<std::string> information;
 
-		/// @brief contributors to this beatmap
-		std::vector<Contributor> contributors;
-
 		/// @brief if set, the custom diff name
 		std::optional<std::string> customDiffName;
 		/// @brief if set, the custom diff hover text
 		std::optional<std::string> customDiffLabel;
 		/// @brief if set, the environment type
 		std::optional<std::string> environmentType;
-		/// @brief if set, the amount of sabers (probably 1 or 2)
-		std::optional<int> saberCount;
+		/// @brief if set, whether this map overrides saber count for characteristic
+		std::optional<bool> oneSaber;
 		/// @brief if set, the custom colors for this map
 		std::optional<CustomColors> customColors;
-		/// @brief if set, the amount of sabers (probably 1 or 2)
-		bool showRotationNoteSpawnLines = true;
+		/// @brief whether to show rotation spawn lines
+		std::optional<bool> showRotationNoteSpawnLines;
 
 		/// @brief deserializer method
 		/// @return whether deserialization was succesful
@@ -139,7 +123,24 @@ public:
 
 	/// @brief struct providing basic information about a beatmap
 	struct BasicCustomLevelDetails {
+		/// @brief struct describing a contributor entry
+		struct Contributor {
+			/// @brief name of this contributor
+			std::string name;
+			/// @brief what did they do?
+			std::string role;
+			/// @brief path to the icon to display for this contributor
+			std::filesystem::path iconPath;
+
+			/// @brief deserializer method
+			/// @return whether deserialization was succesful
+			bool Deserialize(ValueUTF16 const& value);
+		};
+
 		std::unordered_map<std::string, BasicCustomDifficultyBeatmapDetailsSet> characteristicNameToBeatmapDetailsSet;
+
+		/// @brief contributors to this level
+		std::vector<Contributor> contributors;
 
 		/// @brief tries to get the characteristic details
 		/// @param characteristic characteristic name
@@ -170,10 +171,40 @@ public:
 		bool Deserialize(ValueUTF16 const& value);
 	};
 
+	/// @brief tries to get the basic level details for this savedata
+	/// @return optional reference to the parsed data, or nullopt if parse was unsuccesful
 	std::optional<std::reference_wrapper<BasicCustomLevelDetails const>> TryGetBasicLevelDetails();
 
+	/// @brief tries to get the basic level details for this savedata
+	/// @param outDetails reference to your output variable. will copy construct
+	/// @return true if available, false if not
+	bool TryGetBasicLevelDetails(BasicCustomLevelDetails& outDetails);
+
+	/// @brief tries to get the characteristic details
+	/// @param characteristic characteristic name
+	/// @return optional details set, nullopt if not found
+	[[nodiscard]] std::optional<std::reference_wrapper<BasicCustomDifficultyBeatmapDetailsSet const>> TryGetCharacteristic(std::string const& characteristic);
+
+	/// @brief tries to get the characteristic details
+	/// @param characteristic characteristic name
+	/// @param outSet reference to destination details set. will copy construct
+	/// @return true if found, false if not
+	[[nodiscard]] bool TryGetCharacteristic(std::string const& characteristic, BasicCustomDifficultyBeatmapDetailsSet& outSet);
+	/// @brief tries to get the difficulty details for a characteristic
+	/// @param characteristic characteristic name
+	/// @param difficulty the difficulty to get the details for
+	/// @return optional details, nullopt if either characteristic or difficulty not found
+	[[nodiscard]] std::optional<std::reference_wrapper<BasicCustomDifficultyBeatmapDetails const>> TryGetCharacteristicAndDifficulty(std::string const& characteristic, GlobalNamespace::BeatmapDifficulty difficulty);
+
+	/// @brief tries to get the difficulty details for a characteristic
+	/// @param characteristic characteristic name
+	/// @param difficulty the difficulty to get the details for
+	/// @param outDetails reference to your output variable. will copy construct
+	/// @return true if found, false if not
+	[[nodiscard]] bool TryGetCharacteristicAndDifficulty(std::string const& characteristic, GlobalNamespace::BeatmapDifficulty difficulty, BasicCustomDifficultyBeatmapDetails& outDetails);
+
 private:
-	void ParseLevelDetails();
+	bool ParseLevelDetails();
 	std::optional<BasicCustomLevelDetails> _cachedLevelDetails;
 )
 

--- a/shared/CustomJSONData.hpp
+++ b/shared/CustomJSONData.hpp
@@ -9,13 +9,15 @@
 #include "beatsaber-hook/shared/rapidjson/include/rapidjson/document.h"
 
 #include "GlobalNamespace/StandardLevelInfoSaveData.hpp"
+#include "GlobalNamespace/BeatmapDifficulty.hpp"
+#include "UnityEngine/Color.hpp"
 
 namespace SongCore::CustomJSONData {
 using ValueUTF16 = rapidjson::GenericValue<rapidjson::UTF16<char16_t>>;
 using DocumentUTF16 = rapidjson::GenericDocument<rapidjson::UTF16<char16_t>>;
 }
 
-DECLARE_CLASS_CODEGEN(SongCore::CustomJSONData, CustomLevelInfoSaveData, GlobalNamespace::StandardLevelInfoSaveData, 
+DECLARE_CLASS_CODEGEN(SongCore::CustomJSONData, CustomLevelInfoSaveData, GlobalNamespace::StandardLevelInfoSaveData,
     DECLARE_CTOR(ctor,
         StringW songName,
 		StringW songSubName,
@@ -36,10 +38,143 @@ DECLARE_CLASS_CODEGEN(SongCore::CustomJSONData, CustomLevelInfoSaveData, GlobalN
 		ArrayW<GlobalNamespace::StandardLevelInfoSaveData::DifficultyBeatmapSet*> difficultyBeatmapSets
     );
     DECLARE_SIMPLE_DTOR();
-    
+
 public:
     std::shared_ptr<DocumentUTF16> doc;
     std::optional<std::reference_wrapper<const ValueUTF16>> customData;
+
+	/// @brief struct providing basic information about a difficulty beatmap (characteristic + difficulty)
+	struct BasicCustomDifficultyBeatmapDetails {
+		/// @brief struct describing a contributor entry
+		struct Contributor {
+			/// @brief name of this contributor
+			std::string name;
+			/// @brief what did they do?
+			std::string role;
+			/// @brief path to the icon to display for this contributor
+			std::filesystem::path iconPath;
+
+			/// @brief deserializer method
+			/// @return whether deserialization was succesful
+			bool Deserialize(ValueUTF16 const& value);
+		};
+		struct CustomColors {
+			std::optional<UnityEngine::Color> colorLeft;
+			std::optional<UnityEngine::Color> colorRight;
+			std::optional<UnityEngine::Color> envColorRight;
+			std::optional<UnityEngine::Color> envColorLeft;
+			std::optional<UnityEngine::Color> envColorWhite;
+			std::optional<UnityEngine::Color> envColorLeftBoost;
+			std::optional<UnityEngine::Color> envColorRightBoost;
+			std::optional<UnityEngine::Color> envColorWhiteBoost;
+			std::optional<UnityEngine::Color> obstacleColor;
+
+			/// @brief deserializer method
+			/// @return since everything is completely optional, returns true if anything was found, false if nothing was found
+			bool Deserialize(ValueUTF16 const& value);
+		};
+
+		/// @brief characteristic name as parsed from info.dat
+		std::string characteristicName;
+		/// @brief difficulty enum as parsed from info.dat
+		GlobalNamespace::BeatmapDifficulty difficulty;
+
+		/// @brief requirements to play this beatmap
+		std::vector<std::string> requirements;
+		/// @brief suggestions for this beatmap
+		std::vector<std::string> suggestions;
+		/// @brief warnings for this beatmap
+		std::vector<std::string> warnings;
+		/// @brief information for this beatmap
+		std::vector<std::string> information;
+
+		/// @brief contributors to this beatmap
+		std::vector<Contributor> contributors;
+
+		/// @brief if set, the custom diff name
+		std::optional<std::string> customDiffName;
+		/// @brief if set, the custom diff hover text
+		std::optional<std::string> customDiffLabel;
+		/// @brief if set, the environment type
+		std::optional<std::string> environmentType;
+		/// @brief if set, the amount of sabers (probably 1 or 2)
+		std::optional<int> saberCount;
+		/// @brief if set, the custom colors for this map
+		std::optional<CustomColors> customColors;
+		/// @brief if set, the amount of sabers (probably 1 or 2)
+		bool showRotationNoteSpawnLines = true;
+
+		/// @brief deserializer method
+		/// @return whether deserialization was succesful
+		bool Deserialize(ValueUTF16 const& value);
+	};
+
+	/// @brief struct providing basic information about a difficulty beatmap set (characteristic)
+	struct BasicCustomDifficultyBeatmapDetailsSet {
+		/// @brief map of GlobalNamespace::BeatmapDifficulty to BasicCustomDifficultyBeatmapDetails
+		std::unordered_map<GlobalNamespace::BeatmapDifficulty::__BeatmapDifficulty_Unwrapped, BasicCustomDifficultyBeatmapDetails> difficultyToDifficultyBeatmapDetails;
+		/// @brief characteristic name as parsed from info.dat
+		std::string characteristicName;
+		/// @brief optional custom label (hover text)
+		std::optional<std::string> characteristicLabel;
+		/// @brief optional custom icon filename (combine with customLevelPath)
+		std::optional<std::string> characteristicIconImageFileName;
+
+		/// @brief tries to get the difficulty details for a characteristic
+		/// @param characteristic characteristic name
+		/// @param difficulty the difficulty to get the details for
+		/// @return optional details, nullopt if either characteristic or difficulty not found
+		[[nodiscard]] std::optional<std::reference_wrapper<BasicCustomDifficultyBeatmapDetails const>> TryGetDifficulty(GlobalNamespace::BeatmapDifficulty difficulty) const;
+
+		/// @brief tries to get the difficulty details for a characteristic
+		/// @param difficulty the difficulty to get the details for
+		/// @param outDetails reference to your output variable. will copy construct
+		/// @return true if found, false if not
+		[[nodiscard]] bool TryGetDifficulty(GlobalNamespace::BeatmapDifficulty difficulty, BasicCustomDifficultyBeatmapDetails& outDetails) const;
+
+		/// @brief deserializer method
+		/// @return whether deserialization was succesful
+		bool Deserialize(ValueUTF16 const& value);
+	};
+
+	/// @brief struct providing basic information about a beatmap
+	struct BasicCustomLevelDetails {
+		std::unordered_map<std::string, BasicCustomDifficultyBeatmapDetailsSet> characteristicNameToBeatmapDetailsSet;
+
+		/// @brief tries to get the characteristic details
+		/// @param characteristic characteristic name
+		/// @return optional details set, nullopt if not found
+		[[nodiscard]] std::optional<std::reference_wrapper<BasicCustomDifficultyBeatmapDetailsSet const>> TryGetCharacteristic(std::string const& characteristic) const;
+
+		/// @brief tries to get the characteristic details
+		/// @param characteristic characteristic name
+		/// @param outSet reference to destination details set. will copy construct
+		/// @return true if found, false if not
+		[[nodiscard]] bool TryGetCharacteristic(std::string const& characteristic, BasicCustomDifficultyBeatmapDetailsSet& outSet) const;
+
+		/// @brief tries to get the difficulty details for a characteristic
+		/// @param characteristic characteristic name
+		/// @param difficulty the difficulty to get the details for
+		/// @return optional details, nullopt if either characteristic or difficulty not found
+		[[nodiscard]] std::optional<std::reference_wrapper<BasicCustomDifficultyBeatmapDetails const>> TryGetCharacteristicAndDifficulty(std::string const& characteristic, GlobalNamespace::BeatmapDifficulty difficulty) const;
+
+		/// @brief tries to get the difficulty details for a characteristic
+		/// @param characteristic characteristic name
+		/// @param difficulty the difficulty to get the details for
+		/// @param outDetails reference to your output variable. will copy construct
+		/// @return true if found, false if not
+		[[nodiscard]] bool TryGetCharacteristicAndDifficulty(std::string const& characteristic, GlobalNamespace::BeatmapDifficulty difficulty, BasicCustomDifficultyBeatmapDetails& outDetails) const;
+
+		/// @brief deserializer method
+		/// @return whether deserialization was succesful
+		bool Deserialize(ValueUTF16 const& value);
+	};
+
+	std::optional<std::reference_wrapper<BasicCustomLevelDetails const>> TryGetBasicLevelDetails();
+
+private:
+	void ParseLevelDetails();
+	std::optional<BasicCustomLevelDetails> _cachedLevelDetails;
 )
 
 DECLARE_CLASS_CODEGEN(SongCore::CustomJSONData, CustomDifficultyBeatmap, GlobalNamespace::StandardLevelInfoSaveData::DifficultyBeatmap,
@@ -56,4 +191,7 @@ DECLARE_CLASS_CODEGEN(SongCore::CustomJSONData, CustomDifficultyBeatmap, GlobalN
 
 public:
 	std::optional<std::reference_wrapper<const ValueUTF16>> customData;
+
+
+
 )

--- a/shared/PlayButtonInteractable.hpp
+++ b/shared/PlayButtonInteractable.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "custom-types/shared/macros.hpp"
+#include "Zenject/IInitializable.hpp"
+#include "System/IDisposable.hpp"
+#include "System/Object.hpp"
+#include "SongCore.hpp"
+
+DECLARE_CLASS_CODEGEN_INTERFACES(SongCore, PlayButtonInteractable, System::Object, std::vector<Il2CppClass*>({classof(Zenject::IInitializable*), classof(System::IDisposable*)}),
+    DECLARE_CTOR(ctor);
+
+    DECLARE_OVERRIDE_METHOD_MATCH(void, Initialize, &Zenject::IInitializable::Initialize);
+    DECLARE_OVERRIDE_METHOD_MATCH(void, Dispose, &System::IDisposable::Dispose);
+    public:
+
+#ifdef MOD_ID
+        /// @brief disallows the playbutton to be enabled by your mod
+        /// @param modInfo the modinfo for the mod disabling the play button
+        /// @param reason optional reason for why it was disabled
+        void DisablePlayButton(std::string modID = MOD_ID, std::string reason = "");
+
+        /// @brief allows the playbutton to be enabled by your mod
+        /// @param modInfo the modinfo for the mod disabling the play button
+        void EnablePlayButton(std::string modID = MOD_ID);
+#else
+        /// @brief disallows the playbutton to be enabled by your mod
+        /// @param modInfo the modinfo for the mod disabling the play button
+        /// @param reason optional reason for why it was disabled
+        void DisablePlayButton(std::string modID, std::string reason = "");
+
+        /// @brief allows the playbutton to be enabled by your mod
+        /// @param modInfo the modinfo for the mod disabling the play button
+        void EnablePlayButton(std::string modID);
+#endif
+        using PlayButtonDisablingModInfo = SongCore::API::PlayButton::PlayButtonDisablingModInfo;
+
+        /// @brief event ran when the disabling mod infos change, like when Disable or Enable Play button is called from any mod, provides a span of the disabling mod ids and reasons
+        UnorderedEventCallback<std::span<PlayButtonDisablingModInfo const>> PlayButtonDisablingModsChanged;
+
+        /// @brief provides a span of the disabling mod infos
+        std::span<PlayButtonDisablingModInfo const> GetPlayButtonDisablingModInfos();
+        __declspec(property(get=GetPlayButtonDisablingModInfos)) std::span<PlayButtonDisablingModInfo const> PlayButtonDisablingModInfos;
+    private:
+        /// @brief invokes the PlayButtonDisablingModsChanged event
+        void InvokePlayButtonDisablingModsChanged(std::span<PlayButtonDisablingModInfo const> disablingModInfos);
+)

--- a/shared/SongCore.hpp
+++ b/shared/SongCore.hpp
@@ -40,6 +40,41 @@ namespace SongCore::API {
         SONGCORE_EXPORT UnorderedEventCallback<std::string_view, Capabilities::CapabilityEventKind>& GetCapabilitiesUpdatedEvent();
     }
 
+    namespace PlayButton {
+        struct SONGCORE_EXPORT PlayButtonDisablingModInfo {
+            std::string modID;
+            std::string reason;
+        };
+
+        #ifdef MOD_ID
+        /// @brief disallows the playbutton to be enabled by your mod
+        /// @param modInfo the modinfo for the mod disabling the play button
+        /// @param reason optional reason for why it was disabled
+        SONGCORE_EXPORT void DisablePlayButton(std::string modID = MOD_ID, std::string reason = "");
+
+        /// @brief allows the playbutton to be enabled by your mod
+        /// @param modInfo the modinfo for the mod disabling the play button
+        SONGCORE_EXPORT void EnablePlayButton(std::string modID = MOD_ID);
+
+        #else
+        /// @brief disallows the playbutton to be enabled by your mod
+        /// @param modInfo the modinfo for the mod disabling the play button
+        /// @param reason optional reason for why it was disabled
+        SONGCORE_EXPORT void DisablePlayButton(std::string modID, std::string reason = "");
+
+        /// @brief allows the playbutton to be enabled by your mod
+        /// @param modInfo the modinfo for the mod disabling the play button
+        SONGCORE_EXPORT void EnablePlayButton(std::string modID);
+
+        #endif
+
+        /// @brief event ran when the disabling mod infos change, like when Disable or Enable Play button is called from any mod, provides a span of the disabling mod ids and reasons
+        SONGCORE_EXPORT UnorderedEventCallback<std::span<PlayButtonDisablingModInfo const>>& GetPlayButtonDisablingModsChangedEvent();
+
+        /// @brief provides a span of the disabling mod infos
+        SONGCORE_EXPORT std::span<PlayButtonDisablingModInfo const> GetPlayButtonDisablingModInfos();
+    }
+
     namespace Characteristics {
         enum SONGCORE_EXPORT CharacteristicEventKind {
             Registered = 0,

--- a/src/CustomJSONData.cpp
+++ b/src/CustomJSONData.cpp
@@ -1,53 +1,268 @@
 #include "CustomJSONData.hpp"
+#include "paper/shared/utfcpp/source/utf8.h"
+#include <cctype>
+#include <string>
 
 using namespace GlobalNamespace;
-using namespace SongCore::CustomJSONData;
 
 DEFINE_TYPE(SongCore::CustomJSONData, CustomLevelInfoSaveData);
-
-void CustomLevelInfoSaveData::ctor(
-	StringW songName,
-	StringW songSubName,
-	StringW songAuthorName,
-	StringW levelAuthorName,
-	float beatsPerMinute,
-	float songTimeOffset,
-	float shuffle,
-	float shufflePeriod,
-	float previewStartTime,
-	float previewDuration,
-	StringW songFilename,
-	StringW coverImageFilename,
-	StringW environmentName,
-	StringW allDirectionsEnvironmentName,
-	ArrayW<::StringW> environmentNames,
-	ArrayW<GlobalNamespace::BeatmapLevelColorSchemeSaveData*> colorSchemes,
-	ArrayW<GlobalNamespace::StandardLevelInfoSaveData::DifficultyBeatmapSet*> difficultyBeatmapSets
-) {
-	INVOKE_CTOR();
-
-	_ctor(
-		songName,
-		songSubName,
-		songAuthorName,
-		levelAuthorName,
-		beatsPerMinute,
-		songTimeOffset,
-		shuffle,
-		shufflePeriod,
-		previewStartTime,
-		previewDuration,
-		songFilename,
-		coverImageFilename,
-		environmentName,
-		allDirectionsEnvironmentName,
-		environmentNames,
-		colorSchemes,
-		difficultyBeatmapSets
-	);
-}
-
 DEFINE_TYPE(SongCore::CustomJSONData, CustomDifficultyBeatmap);
+
+namespace SongCore::CustomJSONData {
+
+	void CustomLevelInfoSaveData::ctor(
+		StringW songName,
+		StringW songSubName,
+		StringW songAuthorName,
+		StringW levelAuthorName,
+		float beatsPerMinute,
+		float songTimeOffset,
+		float shuffle,
+		float shufflePeriod,
+		float previewStartTime,
+		float previewDuration,
+		StringW songFilename,
+		StringW coverImageFilename,
+		StringW environmentName,
+		StringW allDirectionsEnvironmentName,
+		ArrayW<::StringW> environmentNames,
+		ArrayW<GlobalNamespace::BeatmapLevelColorSchemeSaveData*> colorSchemes,
+		ArrayW<GlobalNamespace::StandardLevelInfoSaveData::DifficultyBeatmapSet*> difficultyBeatmapSets
+	) {
+		INVOKE_CTOR();
+
+		_ctor(
+			songName,
+			songSubName,
+			songAuthorName,
+			levelAuthorName,
+			beatsPerMinute,
+			songTimeOffset,
+			shuffle,
+			shufflePeriod,
+			previewStartTime,
+			previewDuration,
+			songFilename,
+			coverImageFilename,
+			environmentName,
+			allDirectionsEnvironmentName,
+			environmentNames,
+			colorSchemes,
+			difficultyBeatmapSets
+		);
+	}
+
+	std::optional<std::reference_wrapper<const CustomLevelInfoSaveData::BasicCustomLevelDetails>> CustomLevelInfoSaveData::TryGetBasicLevelDetails() {
+		if (_cachedLevelDetails.has_value()) return _cachedLevelDetails;
+		ParseLevelDetails();
+		return _cachedLevelDetails;
+	}
+
+	void CustomLevelInfoSaveData::ParseLevelDetails() {
+		BasicCustomLevelDetails levelDetails;
+
+		if (!levelDetails.Deserialize(doc->GetObject())) return;
+
+		_cachedLevelDetails = std::move(levelDetails);
+	}
+
+	std::optional<std::reference_wrapper<CustomLevelInfoSaveData::BasicCustomDifficultyBeatmapDetailsSet const>> CustomLevelInfoSaveData::BasicCustomLevelDetails::TryGetCharacteristic(std::string const& characteristic) const {
+		auto charItr = characteristicNameToBeatmapDetailsSet.find(characteristic);
+		if (charItr != characteristicNameToBeatmapDetailsSet.end()) return charItr->second;
+		return std::nullopt;
+	}
+
+	bool CustomLevelInfoSaveData::BasicCustomLevelDetails::TryGetCharacteristic(std::string const& characteristic, CustomLevelInfoSaveData::BasicCustomDifficultyBeatmapDetailsSet& outDetailsSet) const {
+		auto charItr = characteristicNameToBeatmapDetailsSet.find(characteristic);
+		if (charItr != characteristicNameToBeatmapDetailsSet.end()) {
+			outDetailsSet = charItr->second;
+			return true;
+		}
+		return false;
+	}
+
+	std::optional<std::reference_wrapper<CustomLevelInfoSaveData::BasicCustomDifficultyBeatmapDetails const>> CustomLevelInfoSaveData::BasicCustomLevelDetails::TryGetCharacteristicAndDifficulty(std::string const& characteristic, GlobalNamespace::BeatmapDifficulty difficulty) const {
+		auto charItr = characteristicNameToBeatmapDetailsSet.find(characteristic);
+		if (charItr != characteristicNameToBeatmapDetailsSet.end()) return charItr->second.TryGetDifficulty(difficulty);
+		return std::nullopt;
+	}
+
+	bool CustomLevelInfoSaveData::BasicCustomLevelDetails::TryGetCharacteristicAndDifficulty(std::string const& characteristic, GlobalNamespace::BeatmapDifficulty difficulty, BasicCustomDifficultyBeatmapDetails& outDetails) const {
+		auto charItr = characteristicNameToBeatmapDetailsSet.find(characteristic);
+		if (charItr != characteristicNameToBeatmapDetailsSet.end()) return charItr->second.TryGetDifficulty(difficulty, outDetails);
+		return false;
+	}
+
+	// this is all the characteristics -> diff sets
+	bool CustomLevelInfoSaveData::BasicCustomLevelDetails::Deserialize(ValueUTF16 const& value) {
+		auto difficultyBeatmapSetsItr = value.FindMember(u"_difficultyBeatmapSets");
+		if (difficultyBeatmapSetsItr == value.MemberEnd() || !difficultyBeatmapSetsItr->value.IsArray()) return false;
+
+		// check each set
+		for (auto& set : difficultyBeatmapSetsItr->value.GetArray()) {
+			auto characteristicName = utf8::utf16to8(set[u"_beatmapCharacteristicName"].Get<std::u16string>());
+			auto& diffSet = characteristicNameToBeatmapDetailsSet[characteristicName];
+			diffSet.characteristicName = characteristicName;
+			diffSet.Deserialize(set);
+		}
+
+		return true;
+	}
+
+	std::optional<std::reference_wrapper<CustomLevelInfoSaveData::BasicCustomDifficultyBeatmapDetails const>> CustomLevelInfoSaveData::BasicCustomDifficultyBeatmapDetailsSet::TryGetDifficulty(GlobalNamespace::BeatmapDifficulty difficulty) const {
+		auto diffItr = difficultyToDifficultyBeatmapDetails.find(difficulty);
+		if (diffItr != difficultyToDifficultyBeatmapDetails.end()) return diffItr->second;
+		return std::nullopt;
+	}
+
+	bool CustomLevelInfoSaveData::BasicCustomDifficultyBeatmapDetailsSet::TryGetDifficulty(GlobalNamespace::BeatmapDifficulty difficulty, CustomLevelInfoSaveData::BasicCustomDifficultyBeatmapDetails& outDetails) const {
+		auto diffItr = difficultyToDifficultyBeatmapDetails.find(difficulty);
+		if (diffItr != difficultyToDifficultyBeatmapDetails.end()) {
+			outDetails = diffItr->second;
+			return true;
+		}
+		return false;
+	}
+
+	GlobalNamespace::BeatmapDifficulty ParseDiff(std::string_view diffName) {
+		static std::pair<std::string, GlobalNamespace::BeatmapDifficulty> diffNameToDiffMap[6] {
+			{ "Easy", GlobalNamespace::BeatmapDifficulty::Easy },
+			{ "Normal", GlobalNamespace::BeatmapDifficulty::Normal },
+			{ "Hard", GlobalNamespace::BeatmapDifficulty::Hard },
+			{ "Expert", GlobalNamespace::BeatmapDifficulty::Expert },
+			{ "ExpertPlus", GlobalNamespace::BeatmapDifficulty::ExpertPlus },
+		};
+
+		for (auto& [name, diff] : diffNameToDiffMap) {
+			if (name == diffName) {
+				return diff;
+			}
+		}
+
+		return GlobalNamespace::BeatmapDifficulty::Easy;
+	}
+
+	// this is the diff set -> difficulties
+	bool CustomLevelInfoSaveData::BasicCustomDifficultyBeatmapDetailsSet::Deserialize(ValueUTF16 const& value) {
+		auto characteristicLabelItr = value.FindMember(u"_characteristicLabel");
+		if (characteristicLabelItr != value.MemberEnd()) characteristicLabel = utf8::utf16to8(characteristicLabelItr->value.Get<std::u16string>());
+
+		auto characteristicIconImageFileNameItr = value.FindMember(u"_characteristicIconImageFileName");
+		if (characteristicIconImageFileNameItr != value.MemberEnd()) characteristicIconImageFileName = utf8::utf16to8(characteristicIconImageFileNameItr->value.Get<std::u16string>());
+
+		auto difficultyBeatmapsItr = value.FindMember(u"_difficultyBeatmaps");
+		if (difficultyBeatmapsItr == value.MemberEnd() || !difficultyBeatmapsItr->value.IsArray()) return false;
+
+		// check each beatmap
+		for (auto& beatmap : difficultyBeatmapsItr->value.GetArray()) {
+			auto diffName = utf8::utf16to8(beatmap[u"_difficulty"].Get<std::u16string>());
+			GlobalNamespace::BeatmapDifficulty diff = ParseDiff(diffName);
+
+			auto& diffData = difficultyToDifficultyBeatmapDetails[diff];
+			diffData.characteristicName = characteristicName;
+			diffData.difficulty = diff;
+			diffData.Deserialize(beatmap);
+		}
+
+		return false;
+	}
+
+	static void ParseSimpleStringArrayInto(ValueUTF16 const& customData, std::u16string_view valueName, std::vector<std::string>& out) {
+		auto arrayItr = customData.FindMember(valueName.data());
+		if (arrayItr == customData.MemberEnd() || !arrayItr->value.IsArray()) return;
+		for (auto& value : arrayItr->value.GetArray()) {
+			out.emplace_back(utf8::utf16to8(value.Get<std::u16string>()));
+		}
+	}
+
+	static void ParseContributorArrayInto(ValueUTF16 const& customData, std::vector<CustomLevelInfoSaveData::BasicCustomDifficultyBeatmapDetails::Contributor>& out) {
+		auto arrayItr = customData.FindMember(u"_contributors");
+		if (arrayItr == customData.MemberEnd() || !arrayItr->value.IsArray()) return;
+		for (auto& value : arrayItr->value.GetArray()) {
+			out.emplace_back().Deserialize(value);
+		}
+	}
+
+	// this is each difficulty individually
+	bool CustomLevelInfoSaveData::BasicCustomDifficultyBeatmapDetails::Deserialize(ValueUTF16 const& value) {
+		auto customDataItr = value.FindMember(u"_customData");
+		if (customDataItr == value.MemberEnd()) return false;
+		auto& customData = customDataItr->value;
+		auto memberEnd = customData.MemberEnd();
+
+		auto environmentTypeItr = customData.FindMember(u"_environmentType");
+		if (environmentTypeItr != memberEnd) environmentType = utf8::utf16to8(environmentTypeItr->value.Get<std::u16string>());
+
+		auto showRotationNoteSpawnLinesItr = customData.FindMember(u"_showRotationNoteSpawnLines");
+		if (showRotationNoteSpawnLinesItr != memberEnd) showRotationNoteSpawnLines = showRotationNoteSpawnLinesItr->value.GetBool();
+
+		auto oneSaberItr = customData.FindMember(u"_oneSaber");
+		if (oneSaberItr != memberEnd) saberCount = 2 - int(oneSaberItr->value.GetBool());
+
+		ParseSimpleStringArrayInto(customData, u"_requirements", requirements);
+		ParseSimpleStringArrayInto(customData, u"_suggestions", suggestions);
+		ParseSimpleStringArrayInto(customData, u"_warnings", warnings);
+		ParseSimpleStringArrayInto(customData, u"_information", information);
+
+		ParseContributorArrayInto(customData, contributors);
+
+		CustomColors customColors;
+		// if any custom colors are deserialized, set the value
+		if (customColors.Deserialize(customData)) this->customColors = std::move(customColors);
+
+		return true;
+	}
+
+	bool CustomLevelInfoSaveData::BasicCustomDifficultyBeatmapDetails::Contributor::Deserialize(ValueUTF16 const& value) {
+		auto memberEnd = value.MemberEnd();
+		auto nameItr = value.FindMember(u"_name");
+		if (nameItr != memberEnd && nameItr->value.IsString()) name = utf8::utf16to8(nameItr->value.Get<std::u16string>());
+		auto roleItr = value.FindMember(u"_role");
+		if (roleItr != memberEnd && roleItr->value.IsString()) role = utf8::utf16to8(roleItr->value.Get<std::u16string>());
+		auto iconPathItr = value.FindMember(u"_iconPath");
+		if (iconPathItr != memberEnd && iconPathItr->value.IsString()) iconPath = utf8::utf16to8(iconPathItr->value.Get<std::u16string>());
+
+		return true;
+	}
+
+	static UnityEngine::Color DeserializeColor(ValueUTF16 const& value) {
+		auto memberEnd = value.MemberEnd();
+		float r = 1.0f, g = 1.0f, b = 1.0f, a = 1.0f;
+		auto rItr = value.FindMember(u"r");
+		if (rItr != memberEnd && rItr->value.IsNumber()) r = rItr->value.GetFloat();
+		auto gItr = value.FindMember(u"g");
+		if (gItr != memberEnd && gItr->value.IsNumber()) g = gItr->value.GetFloat();
+		auto bItr = value.FindMember(u"b");
+		if (bItr != memberEnd && bItr->value.IsNumber()) b = bItr->value.GetFloat();
+		auto aItr = value.FindMember(u"a");
+		if (aItr != memberEnd && aItr->value.IsNumber()) a = aItr->value.GetFloat();
+
+		return {r, g, b, a};
+	}
+
+	#define DESERIALIZE_OPT_COLOR(color_) do {							\
+		auto itr = value.FindMember(u"_" u## #color_);                  \
+		if (itr != memberEnd && itr->value.IsObject()) {                \
+			color_ = DeserializeColor(itr->value);                      \
+			foundAnything = true;                                       \
+		}                                                               \
+	} while (0)
+
+    bool CustomLevelInfoSaveData::BasicCustomDifficultyBeatmapDetails::CustomColors::Deserialize(ValueUTF16 const& value) {
+		auto memberEnd = value.MemberEnd();
+		bool foundAnything = false;
+		DESERIALIZE_OPT_COLOR(colorLeft);
+		DESERIALIZE_OPT_COLOR(colorRight);
+		DESERIALIZE_OPT_COLOR(envColorRight);
+		DESERIALIZE_OPT_COLOR(envColorLeft);
+		DESERIALIZE_OPT_COLOR(envColorWhite);
+		DESERIALIZE_OPT_COLOR(envColorLeftBoost);
+		DESERIALIZE_OPT_COLOR(envColorRightBoost);
+		DESERIALIZE_OPT_COLOR(envColorWhiteBoost);
+		DESERIALIZE_OPT_COLOR(obstacleColor);
+
+		return foundAnything;
+	}
 
 void CustomDifficultyBeatmap::ctor(
 	StringW difficultyName,
@@ -69,4 +284,5 @@ void CustomDifficultyBeatmap::ctor(
 		beatmapColorSchemeIdx,
 		environmentNameIdx
 	);
+}
 }

--- a/src/CustomJSONData.cpp
+++ b/src/CustomJSONData.cpp
@@ -210,14 +210,21 @@ namespace SongCore::CustomJSONData {
 
 	// this is the diff set -> difficulties
 	bool CustomLevelInfoSaveData::BasicCustomDifficultyBeatmapDetailsSet::Deserialize(ValueUTF16 const& value) {
-		auto characteristicLabelItr = value.FindMember(u"_characteristicLabel");
-		if (characteristicLabelItr != value.MemberEnd()) characteristicLabel = utf8::utf16to8(characteristicLabelItr->value.Get<std::u16string>());
+		auto memberEnd = value.MemberEnd();
+		auto customDataItr = value.FindMember(u"_customData");
+		if (customDataItr != memberEnd && customDataItr->value.IsObject()) {
+			auto& customData = customDataItr->value;
+			auto memberEnd = customData.MemberEnd();
 
-		auto characteristicIconImageFileNameItr = value.FindMember(u"_characteristicIconImageFileName");
-		if (characteristicIconImageFileNameItr != value.MemberEnd()) characteristicIconImageFileName = utf8::utf16to8(characteristicIconImageFileNameItr->value.Get<std::u16string>());
+			auto characteristicLabelItr = customData.FindMember(u"_characteristicLabel");
+			if (characteristicLabelItr != memberEnd && characteristicLabelItr->value.IsString()) characteristicLabel = utf8::utf16to8(characteristicLabelItr->value.Get<std::u16string>());
+
+			auto characteristicIconImageFileNameItr = customData.FindMember(u"_characteristicIconImageFileName");
+			if (characteristicIconImageFileNameItr != memberEnd && characteristicIconImageFileNameItr->value.IsString()) characteristicIconImageFileName = utf8::utf16to8(characteristicIconImageFileNameItr->value.Get<std::u16string>());
+		}
 
 		auto difficultyBeatmapsItr = value.FindMember(u"_difficultyBeatmaps");
-		if (difficultyBeatmapsItr == value.MemberEnd() || !difficultyBeatmapsItr->value.IsArray()) return false;
+		if (difficultyBeatmapsItr == memberEnd || !difficultyBeatmapsItr->value.IsArray()) return false;
 
 		// check each beatmap
 		for (auto& beatmap : difficultyBeatmapsItr->value.GetArray()) {
@@ -230,7 +237,7 @@ namespace SongCore::CustomJSONData {
 			diffData.Deserialize(beatmap);
 		}
 
-		return false;
+		return true;
 	}
 
 	static void ParseSimpleStringArrayInto(ValueUTF16 const& customData, std::u16string_view valueName, std::vector<std::string>& out) {
@@ -247,6 +254,9 @@ namespace SongCore::CustomJSONData {
 		if (customDataItr == value.MemberEnd()) return false;
 		auto& customData = customDataItr->value;
 		auto memberEnd = customData.MemberEnd();
+
+		auto difficultyLabelItr = customData.FindMember(u"_difficultyLabel");
+		if (difficultyLabelItr != memberEnd) customDiffLabel = utf8::utf16to8(difficultyLabelItr->value.Get<std::u16string>());
 
 		auto environmentTypeItr = customData.FindMember(u"_environmentType");
 		if (environmentTypeItr != memberEnd) environmentType = utf8::utf16to8(environmentTypeItr->value.Get<std::u16string>());

--- a/src/PlayButtonInteractable.cpp
+++ b/src/PlayButtonInteractable.cpp
@@ -1,0 +1,34 @@
+#include "PlayButtonInteractable.hpp"
+#include "SongCore.hpp"
+
+DEFINE_TYPE(SongCore, PlayButtonInteractable);
+
+namespace SongCore {
+    void PlayButtonInteractable::ctor() {
+        INVOKE_CTOR();
+    }
+
+    void PlayButtonInteractable::Initialize() {
+        SongCore::API::PlayButton::GetPlayButtonDisablingModsChangedEvent() += {&PlayButtonInteractable::InvokePlayButtonDisablingModsChanged, this};
+    }
+
+    void PlayButtonInteractable::Dispose() {
+        SongCore::API::PlayButton::GetPlayButtonDisablingModsChangedEvent() -= {&PlayButtonInteractable::InvokePlayButtonDisablingModsChanged, this};
+    }
+
+    void PlayButtonInteractable::DisablePlayButton(std::string modID, std::string reason) {
+        return SongCore::API::PlayButton::DisablePlayButton(modID, reason);
+    }
+
+    void PlayButtonInteractable::EnablePlayButton(std::string modID) {
+        return SongCore::API::PlayButton::EnablePlayButton(modID);
+    }
+
+    std::span<PlayButtonInteractable::PlayButtonDisablingModInfo const> PlayButtonInteractable::GetPlayButtonDisablingModInfos() {
+        return SongCore::API::PlayButton::GetPlayButtonDisablingModInfos();
+    }
+
+    void PlayButtonInteractable::InvokePlayButtonDisablingModsChanged(std::span<PlayButtonDisablingModInfo const> disablingModInfos) {
+        PlayButtonDisablingModsChanged.invoke(disablingModInfos);
+    }
+}

--- a/src/SongLoader/RuntimeSongLoader.cpp
+++ b/src/SongLoader/RuntimeSongLoader.cpp
@@ -451,7 +451,7 @@ namespace SongCore::SongLoader {
         auto hashOpt = Utils::GetCustomLevelHash(levelPath, saveData);
         hashOut = *hashOpt;
 
-        std::string levelId = fmt::format("{}{}{}", CUSTOM_LEVEL_PREFIX_ID, hashOut, wip ? "" : " WIP");
+        std::string levelId = fmt::format("{}{}{}", CUSTOM_LEVEL_PREFIX_ID, hashOut, wip ? " WIP" : "");
 
         auto songName = saveData->songName;
         FixEmptyString(songName)

--- a/src/UI/ColorsOptions.cpp
+++ b/src/UI/ColorsOptions.cpp
@@ -1,0 +1,75 @@
+#include "UI/ColorsOptions.hpp"
+#include "config.hpp"
+#include "assets.hpp"
+#include "logging.hpp"
+
+#include "UnityEngine/Resources.hpp"
+#include "bsml/shared/BSML.hpp"
+#include "bsml/shared/Helpers/delegates.hpp"
+
+DEFINE_TYPE(SongCore::UI, ColorsOptions);
+
+namespace SongCore::UI {
+    void ColorsOptions::ctor(GlobalNamespace::StandardLevelDetailViewController* levelDetailViewController) {
+        INVOKE_CTOR();
+        _levelDetailViewController = levelDetailViewController;
+        _voidColor = {0.5f, 0.5f, 0.5f, 0.25f};
+        _modalHideAction = BSML::MakeSystemAction<>(
+            [this](){
+                if(onModalHide) onModalHide();
+            }
+        );
+    }
+
+    void ColorsOptions::ShowColors(CustomJSONData::CustomLevelInfoSaveData::BasicCustomDifficultyBeatmapDetails const& details) {
+        if (!_colorsOptionsModal) {
+            BSML::parse_and_construct(Assets::colors_bsml, _levelDetailViewController->_standardLevelDetailView->transform, this);
+        }
+        _colorsOptionsModal->Show();
+        SetColors(details.customColors.value());
+    }
+
+    void ColorsOptions::PostParse() {
+        if (!_selectedColorBG) {
+            WARNING("_selectedColorBG was null in postparse??");
+        }
+        auto colorSchemeViewPrefab = UnityEngine::Resources::FindObjectsOfTypeAll<GlobalNamespace::ColorSchemeView*>()->First();
+        auto colorSchemeViewObject = UnityEngine::Object::Instantiate(colorSchemeViewPrefab->gameObject, _selectedColorBG);
+        _colorSchemeView = colorSchemeViewObject->GetComponent<GlobalNamespace::ColorSchemeView*>();
+        _colorsOptionsModal->onHide = std::bind(&ColorsOptions::Dismiss, this);
+    }
+
+    void ColorsOptions::Dismiss() {
+        _colorsOptionsModal->HMUI::ModalView::Hide(false, _modalHideAction);
+    }
+
+    bool ColorsOptions::get_customSongNoteColors() { return config.customSongNoteColors; }
+    void ColorsOptions::set_customSongNoteColors(bool value) {
+        config.customSongNoteColors = value;
+        SaveConfig();
+    }
+
+    bool ColorsOptions::get_customSongObstacleColors() { return config.customSongObstacleColors; }
+    void ColorsOptions::set_customSongObstacleColors(bool value) {
+        config.customSongObstacleColors = value;
+        SaveConfig();
+    }
+
+    bool ColorsOptions::get_customSongEnvironmentColors() { return config.customSongEnvironmentColors; }
+    void ColorsOptions::set_customSongEnvironmentColors(bool value) {
+        config.customSongEnvironmentColors = value;
+        SaveConfig();
+    }
+
+    void ColorsOptions::SetColors(CustomJSONData::CustomLevelInfoSaveData::BasicCustomDifficultyBeatmapDetails::CustomColors const& colors) {
+        _colorSchemeView->SetColors(
+            colors.colorLeft.value_or(_voidColor),
+            colors.colorRight.value_or(_voidColor),
+            colors.envColorLeft.value_or(_voidColor),
+            colors.envColorRight.value_or(_voidColor),
+            colors.envColorLeftBoost.value_or(_voidColor),
+            colors.envColorRightBoost.value_or(_voidColor),
+            colors.obstacleColor.value_or(_voidColor)
+        );
+    }
+}

--- a/src/UI/IconCache.cpp
+++ b/src/UI/IconCache.cpp
@@ -1,0 +1,96 @@
+#include "UI/IconCache.hpp"
+#include "assets.hpp"
+#include "logging.hpp"
+#include "bsml/shared/Helpers/utilities.hpp"
+#include <fstream>
+#include <ios>
+
+DEFINE_TYPE(SongCore::UI, IconCache);
+
+#define GetIconImpl(fieldname, assetname) do { \
+        if (!fieldname) fieldname = BSML::Utilities::LoadSpriteRaw(Assets::Resources::assetname##_png); \
+        return fieldname; \
+} while(0)
+namespace SongCore::UI {
+    void IconCache::ctor() {
+        INVOKE_CTOR();
+        _pathIcons = IconDict::New_ctor();
+    }
+
+    void IconCache::Dispose() {
+        auto enumerator = _pathIcons->GetEnumerator();
+        while (enumerator.MoveNext()) {
+            auto [path, icon] = enumerator.Current;
+            if (icon && icon->m_CachedPtr) UnityEngine::Object::Destroy(icon);
+        }
+        enumerator.Dispose();
+
+        _pathIcons->Clear();
+        _lastUsedIcons.clear();
+    }
+
+    UnityEngine::Sprite* IconCache::GetIconForPath(std::filesystem::path const& path) {
+        // if path is empty
+        if (path.empty()) return nullptr;
+
+        UnityEngine::Sprite* sprite = nullptr;
+        StringW csPath(path.string());
+        if (_pathIcons->TryGetValue(csPath, byref(sprite))) {
+            PathWasUsed(path);
+            return sprite;
+        }
+
+        // wasn't loaded -> load
+        if (std::filesystem::exists(path)) {
+            std::ifstream in(path, std::ios::in | std::ios::binary | std::ios::ate);
+
+            il2cpp_array_size_t len = in.tellg();
+            in.seekg(0, std::ios::beg);
+            ArrayW<uint8_t> data(len);
+            in.read((char*)data.begin(), len);
+            sprite = BSML::Utilities::LoadSpriteRaw(data);
+
+            _pathIcons->Add(csPath, sprite);
+            PathWasUsed(path);
+        } else {
+            WARNING("Requested icon file @ {} did not exist!", path.string());
+        }
+
+        return sprite;
+    }
+
+    UnityEngine::Sprite* IconCache::GetColorsIcon() { GetIconImpl(_colorsIcon, Colors); }
+    UnityEngine::Sprite* IconCache::GetEnvironmentIcon() { GetIconImpl(_environmentIcon, Environment); }
+    UnityEngine::Sprite* IconCache::GetExtraDiffsIcon() { GetIconImpl(_extraDiffsIcon, ExtraDiffsIcon); }
+    UnityEngine::Sprite* IconCache::GetFolderIcon() { GetIconImpl(_folderIcon, FolderIcon); }
+    UnityEngine::Sprite* IconCache::GetHaveReqIcon() { GetIconImpl(_haveReqIcon, GreenCheck); }
+    UnityEngine::Sprite* IconCache::GetInfoIcon() { GetIconImpl(_infoIcon, Info); }
+    UnityEngine::Sprite* IconCache::GetOneSaberIcon() { GetIconImpl(_oneSaberIcon, OneSaber); }
+    UnityEngine::Sprite* IconCache::GetMissingReqIcon() { GetIconImpl(_missingReqIcon, RedX); }
+    UnityEngine::Sprite* IconCache::GetStandardIcon() { GetIconImpl(_standardIcon, Standard); }
+    UnityEngine::Sprite* IconCache::GetWarningIcon() { GetIconImpl(_warningIcon, Warning); }
+    UnityEngine::Sprite* IconCache::GetHaveSuggestionIcon() { GetIconImpl(_haveSuggestionIcon, YellowCheck); }
+    UnityEngine::Sprite* IconCache::GetMissingSuggestionIcon() { GetIconImpl(_missingSuggestionIcon, YellowX); }
+
+    void IconCache::PathWasUsed(std::filesystem::path const& path) {
+        auto itr = std::find(_lastUsedIcons.begin(), _lastUsedIcons.end(), path);
+        if (itr != _lastUsedIcons.end()) { // we found this path, so move it to the back
+            _lastUsedIcons.erase(itr);
+            _lastUsedIcons.emplace_back(path);
+        } else { // path was not found, add it to the back
+            _lastUsedIcons.emplace_back(path);
+            if (_lastUsedIcons.size() > MAX_ICON_CACHE_COUNT) { // check if we have too many now that we added one, if so, remove and destroy it
+                auto start = _lastUsedIcons.begin();
+                StringW csPath(start->string());
+                _lastUsedIcons.erase(start);
+
+                if (_pathIcons->ContainsKey(csPath)) {
+                    auto sprite = _pathIcons->Item[csPath];
+                    _pathIcons->Remove(csPath);
+                    UnityEngine::Object::Destroy(sprite);
+                }
+
+            }
+        }
+    }
+}

--- a/src/UI/PlayButtonsUpdater.cpp
+++ b/src/UI/PlayButtonsUpdater.cpp
@@ -12,9 +12,8 @@
 DEFINE_TYPE(SongCore::UI, PlayButtonsUpdater);
 
 namespace SongCore::UI {
-    void PlayButtonsUpdater::ctor(GlobalNamespace::StandardLevelDetailViewController* levelDetailViewController,  GlobalNamespace::LevelSelectionNavigationController* levelSelectionNavigationController, PlayButtonInteractable* playButtonInteractable, Capabilities* capabilities) {
+    void PlayButtonsUpdater::ctor(GlobalNamespace::StandardLevelDetailViewController* levelDetailViewController,  PlayButtonInteractable* playButtonInteractable, Capabilities* capabilities) {
         _levelDetailViewController = levelDetailViewController;
-        _levelSelectionNavigationController = levelSelectionNavigationController;
         _playButtonInteractable;
         _capabilities = capabilities;
     }

--- a/src/UI/PlayButtonsUpdater.cpp
+++ b/src/UI/PlayButtonsUpdater.cpp
@@ -1,0 +1,155 @@
+#include "UI/PlayButtonsUpdater.hpp"
+#include "CustomJSONData.hpp"
+#include "logging.hpp"
+
+#include "GlobalNamespace/IDifficultyBeatmapSet.hpp"
+#include "GlobalNamespace/IPreviewBeatmapLevel.hpp"
+#include "GlobalNamespace/BeatmapDifficulty.hpp"
+
+#include "bsml/shared/Helpers/delegates.hpp"
+#include <string_view>
+
+DEFINE_TYPE(SongCore::UI, PlayButtonsUpdater);
+
+namespace SongCore::UI {
+    void PlayButtonsUpdater::ctor(GlobalNamespace::StandardLevelDetailViewController* levelDetailViewController,  GlobalNamespace::LevelSelectionNavigationController* levelSelectionNavigationController, PlayButtonInteractable* playButtonInteractable, Capabilities* capabilities) {
+        _levelDetailViewController = levelDetailViewController;
+        _levelSelectionNavigationController = levelSelectionNavigationController;
+        _playButtonInteractable;
+        _capabilities = capabilities;
+    }
+
+    void PlayButtonsUpdater::Initialize() {
+        _playButton = _levelDetailViewController->_standardLevelDetailView->actionButton;
+        _practiceButton = _levelDetailViewController->_standardLevelDetailView->practiceButton;
+        _anyDisablingModInfos = !_playButtonInteractable->PlayButtonDisablingModInfos.empty();
+
+        _changeDifficultyBeatmapAction = BSML::MakeSystemAction<UnityW<GlobalNamespace::StandardLevelDetailViewController>, GlobalNamespace::IDifficultyBeatmap*>(
+            std::function<void(UnityW<GlobalNamespace::StandardLevelDetailViewController>, GlobalNamespace::IDifficultyBeatmap*)>(
+                std::bind(&PlayButtonsUpdater::BeatmapLevelSelected, this, std::placeholders::_1, std::placeholders::_2)
+            )
+        );
+
+        _levelDetailViewController->add_didChangeDifficultyBeatmapEvent(_changeDifficultyBeatmapAction);
+
+        _changeContentAction = BSML::MakeSystemAction<UnityW<GlobalNamespace::StandardLevelDetailViewController>, GlobalNamespace::StandardLevelDetailViewController::ContentType>(
+            std::function<void(UnityW<GlobalNamespace::StandardLevelDetailViewController>, GlobalNamespace::StandardLevelDetailViewController::ContentType)>(
+                std::bind(&PlayButtonsUpdater::LevelDetailContentChanged, this, std::placeholders::_1, std::placeholders::_2)
+            )
+        );
+
+        _levelDetailViewController->add_didChangeContentEvent(_changeContentAction);
+    }
+
+    void PlayButtonsUpdater::Dispose() {
+        _levelDetailViewController->remove_didChangeDifficultyBeatmapEvent(_changeDifficultyBeatmapAction);
+        _levelDetailViewController->remove_didChangeContentEvent(_changeContentAction);
+    }
+
+    std::u16string_view DiffToStringView(GlobalNamespace::BeatmapDifficulty diff) {
+        switch (diff) {
+            case GlobalNamespace::BeatmapDifficulty::Easy:
+                return u"Easy";
+            case GlobalNamespace::BeatmapDifficulty::Normal:
+                return u"Normal";
+            case GlobalNamespace::BeatmapDifficulty::Hard:
+                return u"Hard";
+            case GlobalNamespace::BeatmapDifficulty::Expert:
+                return u"Expert";
+            case GlobalNamespace::BeatmapDifficulty::ExpertPlus:
+                return u"ExpertPlus";
+        }
+        return u"Unknown";
+    }
+
+    bool PlayButtonsUpdater::IsPlayerAllowedToStart() {
+        if (_anyDisablingModInfos) return false;
+        if (!_lastSelectedDifficultyBeatmap) return false;
+        if (!_lastSelectedCustomLevel) return true;
+
+        // TODO: get requirements from the selected difficulty beatmap
+        // use diff and characteristic to get the correct customData from the saveData & read requirements from there
+        auto saveData = il2cpp_utils::cast<CustomJSONData::CustomLevelInfoSaveData>(_lastSelectedCustomLevel->standardLevelInfoSaveData);
+        auto diff = _lastSelectedDifficultyBeatmap->get_difficulty();
+        auto characteristic = _lastSelectedDifficultyBeatmap->parentDifficultyBeatmapSet->get_beatmapCharacteristic();
+
+        auto levelDetailsOpt = saveData->TryGetBasicLevelDetails();
+        if (!levelDetailsOpt.has_value()) return true;
+
+        auto& levelDetails = levelDetailsOpt->get();
+        auto difficultyBeatmapDetailsOpt = levelDetails.TryGetCharacteristicAndDifficulty(characteristic->serializedName, diff);
+        if (!difficultyBeatmapDetailsOpt.has_value()) return true;
+
+        auto& difficultyBeatmapDetails = difficultyBeatmapDetailsOpt->get();
+
+        for (auto& requirement : difficultyBeatmapDetails.requirements) {
+            if (!_capabilities->IsCapabilityRegistered(requirement)) return false;
+        }
+
+        return true;
+    }
+
+    void PlayButtonsUpdater::UpdatePlayButtonsState() {
+        auto interactable = IsPlayerAllowedToStart();
+        auto isCustom = _lastSelectedCustomLevel != nullptr;
+        auto isWip = isCustom && _lastSelectedCustomLevel->levelID.ends_with(u" WIP");
+
+        // if we allow player to start at all, practice button is enabled
+        _practiceButton->set_interactable(interactable);
+        // we want it to be "allow to start" and "not wip"
+        _playButton->set_interactable(interactable && !isWip);
+    }
+
+    void PlayButtonsUpdater::LevelDetailContentChanged(GlobalNamespace::StandardLevelDetailViewController* viewController, GlobalNamespace::StandardLevelDetailViewController::ContentType contentType) {
+        if (contentType == GlobalNamespace::StandardLevelDetailViewController::ContentType::OwnedAndReady) {
+            auto difficultyBeatmap = viewController->selectedDifficultyBeatmap;
+            _lastSelectedDifficultyBeatmap = difficultyBeatmap;
+            _lastSelectedCustomLevel = nullptr;
+            if (!difficultyBeatmap) return;
+
+            auto beatmapLevel = difficultyBeatmap->level;
+            auto customBeatmapLevel = il2cpp_utils::try_cast<GlobalNamespace::CustomBeatmapLevel>(beatmapLevel).value_or(nullptr);
+
+            if (customBeatmapLevel) { // custom level
+                HandleCustomLevelWasSelected(customBeatmapLevel, difficultyBeatmap);
+            } else { // vanilla level
+                HandleVanillaLevelWasSelected(beatmapLevel, difficultyBeatmap);
+            }
+        }
+    }
+
+    void PlayButtonsUpdater::BeatmapLevelSelected(GlobalNamespace::StandardLevelDetailViewController* _, GlobalNamespace::IDifficultyBeatmap* difficultyBeatmap) {
+        DEBUG("Something was selected!");
+        _lastSelectedDifficultyBeatmap = difficultyBeatmap;
+        _lastSelectedCustomLevel = nullptr;
+        if (!difficultyBeatmap) return;
+
+        auto beatmapLevel = difficultyBeatmap->level;
+        auto customBeatmapLevel = il2cpp_utils::try_cast<GlobalNamespace::CustomBeatmapLevel>(beatmapLevel).value_or(nullptr);
+        DEBUG("LevelID {} was selected", difficultyBeatmap->level->i___GlobalNamespace__IPreviewBeatmapLevel()->get_levelID());
+
+        if (customBeatmapLevel) {
+            HandleCustomLevelWasSelected(customBeatmapLevel, difficultyBeatmap);
+        } else { // not a custom level
+            HandleVanillaLevelWasSelected(beatmapLevel, difficultyBeatmap);
+        }
+    }
+
+    void PlayButtonsUpdater::HandleVanillaLevelWasSelected(GlobalNamespace::IBeatmapLevel* level, GlobalNamespace::IDifficultyBeatmap* difficultyBeatmap) {
+        _lastSelectedDifficultyBeatmap = difficultyBeatmap;
+        _lastSelectedCustomLevel = nullptr;
+        UpdatePlayButtonsState();
+    }
+
+    void PlayButtonsUpdater::HandleCustomLevelWasSelected(GlobalNamespace::CustomBeatmapLevel* level, GlobalNamespace::IDifficultyBeatmap* difficultyBeatmap) {
+        _lastSelectedDifficultyBeatmap = difficultyBeatmap;
+        _lastSelectedCustomLevel = level;
+        UpdatePlayButtonsState();
+    }
+
+    void PlayButtonsUpdater::HandleDisablingModInfosChanged(std::span<PlayButtonInteractable::PlayButtonDisablingModInfo const> disablingModInfos) {
+        _anyDisablingModInfos = !disablingModInfos.empty();
+
+        UpdatePlayButtonsState();
+    }
+}

--- a/src/UI/RequirementsListManager.cpp
+++ b/src/UI/RequirementsListManager.cpp
@@ -1,0 +1,313 @@
+#include "UI/RequirementsListManager.hpp"
+
+#include "CustomJSONData.hpp"
+#include "GlobalNamespace/StandardLevelDetailView.hpp"
+#include "GlobalNamespace/IDifficultyBeatmapSet.hpp"
+#include "GlobalNamespace/EnvironmentInfoSO.hpp"
+#include "UnityEngine/Transform.hpp"
+#include "UnityEngine/RectTransform.hpp"
+
+#include "logging.hpp"
+#include "config.hpp"
+#include "assets.hpp"
+#include "bsml/shared/BSML.hpp"
+#include "bsml/shared/Helpers/delegates.hpp"
+
+DEFINE_TYPE(SongCore::UI, RequirementsListManager);
+
+static inline UnityEngine::Vector3 operator*(UnityEngine::Vector3 vec, float v) {
+    return {
+        vec.x * v,
+        vec.y * v,
+        vec.z * v
+    };
+}
+
+namespace SongCore::UI {
+    void RequirementsListManager::ctor(GlobalNamespace::StandardLevelDetailViewController* levelDetailViewController, ColorsOptions* colorsOptions, Capabilities* capabilities, IconCache* iconCache) {
+        _levelDetailViewController = levelDetailViewController;
+        _colorsOptions = colorsOptions;
+        _capabilities = capabilities;
+        _iconCache = iconCache;
+
+        _requirementsCells = ListW<BSML::CustomCellInfo*>::New();
+        _unusedRequirementCells = ListW<BSML::CustomCellInfo*>::New();
+        _showColorsOnModalHideAction = BSML::MakeSystemAction<>(std::bind(&RequirementsListManager::ShowColorsOptions, this));
+    }
+
+    void RequirementsListManager::Initialize() {
+        _changeDifficultyBeatmapAction = BSML::MakeSystemAction<UnityW<GlobalNamespace::StandardLevelDetailViewController>, GlobalNamespace::IDifficultyBeatmap*>(
+            std::function<void(UnityW<GlobalNamespace::StandardLevelDetailViewController>, GlobalNamespace::IDifficultyBeatmap*)>(
+                std::bind(&RequirementsListManager::BeatmapLevelSelected, this, std::placeholders::_1, std::placeholders::_2)
+            )
+        );
+
+        _levelDetailViewController->add_didChangeDifficultyBeatmapEvent(_changeDifficultyBeatmapAction);
+
+        _changeContentAction = BSML::MakeSystemAction<UnityW<GlobalNamespace::StandardLevelDetailViewController>, GlobalNamespace::StandardLevelDetailViewController::ContentType>(
+            std::function<void(UnityW<GlobalNamespace::StandardLevelDetailViewController>, GlobalNamespace::StandardLevelDetailViewController::ContentType)>(
+                std::bind(&RequirementsListManager::LevelDetailContentChanged, this, std::placeholders::_1, std::placeholders::_2)
+            )
+        );
+
+        _levelDetailViewController->add_didChangeContentEvent(_changeContentAction);
+        auto levelDetailView = _levelDetailViewController->_standardLevelDetailView;
+        BSML::parse_and_construct("<bg><action-button id='_requirementButton' text='?' anchor-pos-x='31' anchor-pos-y='0' pref-width='12' pref-height='9' on-click='ShowRequirements'/></bg>", levelDetailView->transform, this);
+        _requirementButton->transform->parent->localScale *= 0.7f;
+        _colorsOptions->onModalHide = std::bind(&RequirementsListManager::ShowRequirements, this);
+
+        levelDetailView->_favoriteToggle->transform.cast<UnityEngine::RectTransform>()->anchoredPosition = {3, -2};
+    }
+
+    void RequirementsListManager::Dispose() {
+        _levelDetailViewController->remove_didChangeDifficultyBeatmapEvent(_changeDifficultyBeatmapAction);
+        _levelDetailViewController->remove_didChangeContentEvent(_changeContentAction);
+    }
+
+    void RequirementsListManager::SetRequirementButtonActive(bool active) {
+        _requirementButton->gameObject->SetActive(active);
+    }
+
+    void RequirementsListManager::UpdateRequirementButton() {
+        SetRequirementButtonActive(!_requirementsCells.empty());
+    }
+
+    BSML::CustomCellInfo* RequirementsListManager::GetCellInfo() {
+        if (_unusedRequirementCells.empty()) return BSML::CustomCellInfo::New_ctor();
+
+        auto lastIdx = _unusedRequirementCells.size() - 1;
+        auto last = _unusedRequirementCells[lastIdx];
+        _unusedRequirementCells->Remove(last);
+        return last;
+    }
+
+    void RequirementsListManager::ClearRequirementCells() {
+        for (auto cellInfo : _requirementsCells) _unusedRequirementCells->Add(cellInfo);
+        _requirementsCells->Clear();
+    }
+
+    void RequirementsListManager::UpdateRequirementCells() {
+        DEBUG("Updating requirement cells");
+        ClearRequirementCells();
+
+        if (!_lastSelectedCustomLevel) {
+            DEBUG("Last selected level was not custom! returning...");
+        }
+
+        auto difficulty = _lastSelectedDifficultyBeatmap->difficulty;
+        auto characteristic = _lastSelectedDifficultyBeatmap->parentDifficultyBeatmapSet->beatmapCharacteristic;
+
+        auto saveData = il2cpp_utils::cast<CustomJSONData::CustomLevelInfoSaveData>(_lastSelectedCustomLevel->standardLevelInfoSaveData);
+
+        auto levelDetailsOpt = saveData->TryGetBasicLevelDetails();
+        if (!levelDetailsOpt.has_value()) {
+            DEBUG("level details not aquired! returning...");
+            return;
+        }
+        auto& levelDetails = levelDetailsOpt->get();
+
+        auto diffDetailsOpt = levelDetails.TryGetCharacteristicAndDifficulty(characteristic->serializedName, difficulty);
+
+        if (diffDetailsOpt.has_value()) {
+            auto& diffDetails = diffDetailsOpt->get();
+            for (auto& requirement : diffDetails.requirements) {
+                static ConstString RequirementFound("Requirement Found");
+                static ConstString RequirementMissing("Requirement Missing");
+
+                bool installed = _capabilities->IsCapabilityRegistered(requirement);
+                auto cell = GetCellInfo();
+                cell->text = fmt::format("<size=75%>{}", requirement);
+                cell->subText = installed ? RequirementFound : RequirementMissing;
+                cell->icon = installed ? _iconCache->HaveReqIcon : _iconCache->MissingReqIcon;
+                _requirementsCells.push_back(cell);
+            }
+        }
+
+        for (auto& contributor : levelDetails.contributors) {
+            auto cell = GetCellInfo();
+            cell->text = fmt::format("<size=75%>{}", contributor.name);
+            cell->subText = contributor.role;
+            UnityEngine::Sprite* icon = nullptr;
+            if (!contributor.iconPath.empty()) {
+                std::filesystem::path levelPath(_lastSelectedCustomLevel->customLevelPath);
+                icon = _iconCache->GetIconForPath(levelPath / contributor.iconPath);
+            }
+            cell->icon = icon ? icon : _iconCache->InfoIcon;
+            _requirementsCells.push_back(cell);
+        }
+
+        if (_lastSelectedCustomLevel->levelID.ends_with(u" WIP")) {
+            static ConstString WipText("<size=75%>WIP Level. Please Play in Practice Mode");
+            static ConstString WipSubText("Warning");
+
+            auto cell = GetCellInfo();
+            cell->text = WipText;
+            cell->subText = WipSubText;
+            cell->icon = _iconCache->WarningIcon;
+            _requirementsCells.push_back(cell);
+        }
+
+        if (diffDetailsOpt.has_value()) {
+            auto& diffDetails = diffDetailsOpt->get();
+
+            if (diffDetails.customColors.has_value()) {
+                static ConstString CustomColorsText("<size=75%>Custom Colors Available");
+                static ConstString CustomColorsSubText("Click here to preview & enable or disable it.");
+
+                auto cell = GetCellInfo();
+                cell->text = CustomColorsText;
+                cell->subText = CustomColorsSubText;
+                cell->icon = _iconCache->ColorsIcon;
+                _requirementsCells.push_back(cell);
+            }
+
+            for (auto& warning : diffDetails.warnings) {
+                static ConstString Warning("Warning");
+
+                auto cell = GetCellInfo();
+                cell->text = fmt::format("<size=75%>{}", warning);
+                cell->subText = Warning;
+                cell->icon = _iconCache->WarningIcon;
+                _requirementsCells.push_back(cell);
+            }
+
+            for (auto& information : diffDetails.information) {
+                static ConstString Info("Info");
+
+                auto cell = GetCellInfo();
+                cell->text = fmt::format("<size=75%>{}", information);
+                cell->subText = Info;
+                cell->icon = _iconCache->InfoIcon;
+                _requirementsCells.push_back(cell);
+            }
+
+            for (auto& suggestion : diffDetails.suggestions) {
+                static ConstString SuggestionFound("Suggestion Found");
+                static ConstString SuggestionMissing("Suggestion Missing");
+
+                bool installed = _capabilities->IsCapabilityRegistered(suggestion);
+                auto cell = GetCellInfo();
+                cell->text = suggestion;
+                cell->subText = installed ? SuggestionFound : SuggestionMissing;
+                cell->icon = installed ? _iconCache->HaveSuggestionIcon : _iconCache->MissingSuggestionIcon;
+                _requirementsCells.push_back(cell);
+            }
+
+            if (diffDetails.oneSaber.has_value()) {
+                auto oneSaber = diffDetails.oneSaber.value();
+                static const char* FANCY_ENABLED("[<color=#89ff89>Enabled</color]");
+                static const char* FANCY_DISABLED("[<color=#ff5072>Disabled</color]");
+                static const char* ENABLE("enable");
+                static const char* DISABLE("disable");
+                static const char* FORCED_ONE("Forced One Saber");
+                static const char* FORCED_TWO("Forced Standard");
+
+                auto enabledText = config.disableOneSaberOverride ? FANCY_DISABLED : FANCY_ENABLED;
+                auto enableSubText = config.disableOneSaberOverride ? ENABLE : DISABLE;
+                auto saberCountText = oneSaber ? FORCED_ONE : FORCED_TWO;
+
+                auto cell = GetCellInfo();
+                cell->text = fmt::format("<size=75%>{} {}", saberCountText, enabledText);
+                cell->subText = fmt::format("Map changes saber count, click here to {}", enableSubText);
+                cell->icon = oneSaber ? _iconCache->OneSaberIcon : _iconCache->StandardIcon;
+                _requirementsCells.push_back(cell);
+            }
+
+            // add environment info here if list isn't empty
+            if (!_requirementsCells.empty()) {
+                static ConstString EnvironmentInfo("<size=75%>Environment Info");
+
+                auto cell = GetCellInfo();
+                cell->text = EnvironmentInfo;
+                cell->subText = fmt::format("This Map uses the Environment: {}", _lastSelectedCustomLevel->environmentInfo->environmentName);
+                cell->icon = _iconCache->EnvironmentIcon;
+                _requirementsCells.push_back(cell);
+            }
+        }
+    }
+
+    void RequirementsListManager::ShowRequirements() {
+        if (!_requirementModal) {
+            BSML::parse_and_construct(Assets::requirements_bsml, _requirementButton->transform, this);
+        }
+
+        _listTableData->tableView->ReloadData();
+        _listTableData->tableView->ScrollToCellWithIdx(0, ::HMUI::TableView::ScrollPositionType::Beginning, true);
+
+        _requirementModal->onHide = nullptr;
+        _requirementModal->Show();
+    }
+
+    void RequirementsListManager::ShowColorsOptions() {
+        auto saveData = il2cpp_utils::cast<CustomJSONData::CustomLevelInfoSaveData>(_lastSelectedCustomLevel->standardLevelInfoSaveData);
+        auto characteristic = _lastSelectedDifficultyBeatmap->parentDifficultyBeatmapSet->beatmapCharacteristic;
+        auto difficulty = _lastSelectedDifficultyBeatmap->difficulty;
+        auto diffDetailsOpt = saveData->TryGetCharacteristicAndDifficulty(characteristic->serializedName, difficulty);
+        _colorsOptions->ShowColors(diffDetailsOpt->get());
+    }
+
+    void RequirementsListManager::RequirementCellSelected(HMUI::TableView* tableView, int cellIndex) {
+        auto cell = _requirementsCells[cellIndex];
+        auto selectedIcon = cell->icon;
+
+        if (selectedIcon == _iconCache->ColorsIcon) {
+            _requirementModal->HMUI::ModalView::Hide(false, _showColorsOnModalHideAction);
+        } else if (selectedIcon == _iconCache->StandardIcon || selectedIcon == _iconCache->OneSaberIcon) {
+            config.disableOneSaberOverride = !config.disableOneSaberOverride;
+            SaveConfig();
+            _requirementModal->Hide();
+        }
+        _listTableData->tableView->ClearSelection();
+    }
+
+    void RequirementsListManager::LevelDetailContentChanged(GlobalNamespace::StandardLevelDetailViewController* viewController, GlobalNamespace::StandardLevelDetailViewController::ContentType contentType) {
+        if (contentType == GlobalNamespace::StandardLevelDetailViewController::ContentType::OwnedAndReady) {
+            auto difficultyBeatmap = viewController->selectedDifficultyBeatmap;
+            _lastSelectedDifficultyBeatmap = difficultyBeatmap;
+            _lastSelectedCustomLevel = nullptr;
+            if (!difficultyBeatmap) return;
+
+            auto beatmapLevel = difficultyBeatmap->level;
+            auto customBeatmapLevel = il2cpp_utils::try_cast<GlobalNamespace::CustomBeatmapLevel>(beatmapLevel).value_or(nullptr);
+
+            if (customBeatmapLevel) { // custom level
+                HandleCustomLevelWasSelected(customBeatmapLevel, difficultyBeatmap);
+            } else { // vanilla level
+                HandleVanillaLevelWasSelected(beatmapLevel, difficultyBeatmap);
+            }
+        }
+    }
+
+    void RequirementsListManager::BeatmapLevelSelected(GlobalNamespace::StandardLevelDetailViewController* _, GlobalNamespace::IDifficultyBeatmap* difficultyBeatmap) {
+        _lastSelectedDifficultyBeatmap = difficultyBeatmap;
+        _lastSelectedCustomLevel = nullptr;
+        if (!difficultyBeatmap) return;
+
+        auto beatmapLevel = difficultyBeatmap->level;
+        auto customBeatmapLevel = il2cpp_utils::try_cast<GlobalNamespace::CustomBeatmapLevel>(beatmapLevel).value_or(nullptr);
+
+        if (customBeatmapLevel) {
+            HandleCustomLevelWasSelected(customBeatmapLevel, difficultyBeatmap);
+        } else { // not a custom level
+            HandleVanillaLevelWasSelected(beatmapLevel, difficultyBeatmap);
+        }
+    }
+
+    void RequirementsListManager::HandleVanillaLevelWasSelected(GlobalNamespace::IBeatmapLevel* level, GlobalNamespace::IDifficultyBeatmap* difficultyBeatmap) {
+        _lastSelectedCustomLevel = nullptr;
+        _lastSelectedDifficultyBeatmap = difficultyBeatmap;
+
+        SetRequirementButtonActive(false);
+    }
+
+    void RequirementsListManager::HandleCustomLevelWasSelected(GlobalNamespace::CustomBeatmapLevel* level, GlobalNamespace::IDifficultyBeatmap* difficultyBeatmap) {
+        _lastSelectedCustomLevel = level;
+        _lastSelectedDifficultyBeatmap = difficultyBeatmap;
+
+        UpdateRequirementCells();
+        UpdateRequirementButton();
+    }
+    ListW<BSML::CustomCellInfo*> RequirementsListManager::get_requirementsCells() {
+        return _requirementsCells;
+    }
+}

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -21,6 +21,11 @@ void SaveConfig() {
     doc.SetObject();
     auto& allocator = doc.GetAllocator();
 
+    SET(customSongNoteColors);
+    SET(customSongObstacleColors);
+    SET(customSongEnvironmentColors);
+    SET(disableOneSaberOverride);
+
     auto preferredCustomLevelPath = config.PreferredCustomLevelPath.string();
     doc.AddMember("PreferredCustomLevelPath", rapidjson::Value(preferredCustomLevelPath.c_str(), preferredCustomLevelPath.length(), allocator), allocator);
     rapidjson::Value rootCustomLevelPaths;
@@ -56,6 +61,11 @@ bool LoadConfig() {
     INFO("Loading Config...");
     bool foundEverything = true;
     rapidjson::Document& doc = get_config().config;
+
+    GET(customSongNoteColors);
+    GET(customSongObstacleColors);
+    GET(customSongEnvironmentColors);
+    GET(disableOneSaberOverride);
 
     if (auto PreferredCustomLevelPathItr = doc.FindMember("PreferredCustomLevelPath"); PreferredCustomLevelPathItr != doc.MemberEnd()) {
         config.PreferredCustomLevelPath = PreferredCustomLevelPathItr->value.Get<std::string>();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include "SongCore.hpp"
 #include "SongLoader/RuntimeSongLoader.hpp"
 #include "SongLoader/NavigationControllerUpdater.hpp"
+#include "UI/PlayButtonsUpdater.hpp"
 #include "Utils/Cache.hpp"
 
 #include "UI/ProgressBar.hpp"
@@ -20,6 +21,7 @@
 
 #include "Capabilities.hpp"
 #include "Characteristics.hpp"
+#include "PlayButtonInteractable.hpp"
 #include "include/UI/ProgressBar.hpp"
 #include "config.hpp"
 #include <filesystem>
@@ -85,11 +87,13 @@ SONGCORE_EXPORT_FUNC void late_load() {
         INFO("Installing RSL to location App from SongCore");
         container->BindInterfacesAndSelfTo<SongCore::Capabilities*>()->AsSingle()->NonLazy();
         container->BindInterfacesAndSelfTo<SongCore::Characteristics*>()->AsSingle()->NonLazy();
+        container->BindInterfacesAndSelfTo<SongCore::PlayButtonInteractable*>()->AsSingle()->NonLazy();
         container->BindInterfacesAndSelfTo<SongCore::SongLoader::RuntimeSongLoader*>()->AsSingle()->NonLazy();
     });
 
     z->Install(Lapiz::Zenject::Location::Menu, [](::Zenject::DiContainer* container) {
         container->BindInterfacesAndSelfTo<SongCore::SongLoader::NavigationControllerUpdater*>()->AsSingle()->NonLazy();
+        container->BindInterfacesAndSelfTo<SongCore::UI::PlayButtonsUpdater*>()->AsSingle()->NonLazy();
         Lapiz::Zenject::ZenjectExtensions::FromNewComponentOnNewGameObject(container->BindInterfacesAndSelfTo<SongCore::UI::ProgressBar*>())->AsSingle()->NonLazy();
     });
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,9 @@
 #include "SongLoader/RuntimeSongLoader.hpp"
 #include "SongLoader/NavigationControllerUpdater.hpp"
 #include "UI/PlayButtonsUpdater.hpp"
+#include "UI/IconCache.hpp"
+#include "UI/RequirementsListManager.hpp"
+#include "UI/ColorsOptions.hpp"
 #include "Utils/Cache.hpp"
 
 #include "UI/ProgressBar.hpp"
@@ -89,11 +92,14 @@ SONGCORE_EXPORT_FUNC void late_load() {
         container->BindInterfacesAndSelfTo<SongCore::Characteristics*>()->AsSingle()->NonLazy();
         container->BindInterfacesAndSelfTo<SongCore::PlayButtonInteractable*>()->AsSingle()->NonLazy();
         container->BindInterfacesAndSelfTo<SongCore::SongLoader::RuntimeSongLoader*>()->AsSingle()->NonLazy();
+        container->BindInterfacesAndSelfTo<SongCore::UI::IconCache*>()->AsSingle()->NonLazy();
     });
 
     z->Install(Lapiz::Zenject::Location::Menu, [](::Zenject::DiContainer* container) {
         container->BindInterfacesAndSelfTo<SongCore::SongLoader::NavigationControllerUpdater*>()->AsSingle()->NonLazy();
         container->BindInterfacesAndSelfTo<SongCore::UI::PlayButtonsUpdater*>()->AsSingle()->NonLazy();
+        container->BindInterfacesAndSelfTo<SongCore::UI::RequirementsListManager*>()->AsSingle()->NonLazy();
+        container->BindInterfacesAndSelfTo<SongCore::UI::ColorsOptions*>()->AsSingle()->NonLazy();
         Lapiz::Zenject::ZenjectExtensions::FromNewComponentOnNewGameObject(container->BindInterfacesAndSelfTo<SongCore::UI::ProgressBar*>())->AsSingle()->NonLazy();
     });
 


### PR DESCRIPTION
 - Fixes a bug where the level IDs for WIP levels are flipped with the non-WIP levels (added ` WIP` to ones that shouldn't have it and vice versa)
 - Adds API for mods to disable the play button
 - Adds An updater to handle updating the interactability of the play & practice button
 - Implements parsing custom data from the info.dat into the custom save data type directly as a way of more easily accessing that data and parsing less often.
 - Implements the extra info list onto the level details view