### PR TITLE
[Event Cleanup] Rework things to use SongCore::LevelSelect instead of manually subscribing to the event

### DIFF
--- a/include/UI/ColorsOptions.hpp
+++ b/include/UI/ColorsOptions.hpp
@@ -28,8 +28,10 @@ DECLARE_CLASS_CODEGEN(SongCore::UI, ColorsOptions, System::Object,
         DECLARE_INSTANCE_METHOD(void, set_customSongEnvironmentColors, bool value);
         DECLARE_INSTANCE_METHOD(void, Dismiss);
     public:
+        void Show();
+        void Parse();
+        void SetColors(CustomJSONData::CustomLevelInfoSaveData::BasicCustomDifficultyBeatmapDetails::CustomColors const& colors);
+
         void ShowColors(CustomJSONData::CustomLevelInfoSaveData::BasicCustomDifficultyBeatmapDetails const& details);
         std::function<void()> onModalHide;
-    private:
-        void SetColors(CustomJSONData::CustomLevelInfoSaveData::BasicCustomDifficultyBeatmapDetails::CustomColors const& colors);
 )

--- a/include/UI/PlayButtonsUpdater.hpp
+++ b/include/UI/PlayButtonsUpdater.hpp
@@ -10,6 +10,7 @@
 #include "SongLoader/RuntimeSongLoader.hpp"
 #include "PlayButtonInteractable.hpp"
 #include "Capabilities.hpp"
+#include "LevelSelect.hpp"
 #include "CustomJSONData.hpp"
 
 #include "GlobalNamespace/StandardLevelDetailViewController.hpp"
@@ -19,10 +20,11 @@
 #include "GlobalNamespace/IDifficultyBeatmap.hpp"
 
 DECLARE_CLASS_CODEGEN_INTERFACES(SongCore::UI, PlayButtonsUpdater, System::Object, std::vector<Il2CppClass*>({classof(Zenject::IInitializable*), classof(System::IDisposable*)}),
-    DECLARE_CTOR(ctor, GlobalNamespace::StandardLevelDetailViewController* levelDetailViewController, PlayButtonInteractable* playButtonInteractable, Capabilities* capabilities);
+    DECLARE_CTOR(ctor, GlobalNamespace::StandardLevelDetailViewController* levelDetailViewController, PlayButtonInteractable* playButtonInteractable, Capabilities* capabilities, LevelSelect* levelSelect);
     DECLARE_INSTANCE_FIELD_PRIVATE(GlobalNamespace::StandardLevelDetailViewController*, _levelDetailViewController);
     DECLARE_INSTANCE_FIELD_PRIVATE(PlayButtonInteractable*, _playButtonInteractable);
     DECLARE_INSTANCE_FIELD_PRIVATE(Capabilities*, _capabilities);
+    DECLARE_INSTANCE_FIELD_PRIVATE(LevelSelect*, _levelSelect);
 
     DECLARE_INSTANCE_FIELD_PRIVATE(GlobalNamespace::CustomBeatmapLevel*, _lastSelectedCustomLevel);
     DECLARE_INSTANCE_FIELD_PRIVATE(GlobalNamespace::IDifficultyBeatmap*, _lastSelectedDifficultyBeatmap);
@@ -30,25 +32,19 @@ DECLARE_CLASS_CODEGEN_INTERFACES(SongCore::UI, PlayButtonsUpdater, System::Objec
     DECLARE_INSTANCE_FIELD_PRIVATE(UnityEngine::UI::Button*, _playButton);
     DECLARE_INSTANCE_FIELD_PRIVATE(UnityEngine::UI::Button*, _practiceButton);
 
-    using ChangeDifficultyBeatmapAction = System::Action_2<UnityW<GlobalNamespace::StandardLevelDetailViewController>, GlobalNamespace::IDifficultyBeatmap*>;
-    using ChangeContentAction = System::Action_2<UnityW<GlobalNamespace::StandardLevelDetailViewController>, GlobalNamespace::StandardLevelDetailViewController::ContentType>;
-    DECLARE_INSTANCE_FIELD_PRIVATE(ChangeDifficultyBeatmapAction*, _changeDifficultyBeatmapAction);
-    DECLARE_INSTANCE_FIELD_PRIVATE(ChangeContentAction*, _changeContentAction);
-
     DECLARE_OVERRIDE_METHOD_MATCH(void, Initialize, &Zenject::IInitializable::Initialize);
     DECLARE_OVERRIDE_METHOD_MATCH(void, Dispose, &System::IDisposable::Dispose);
 
     private:
-        void LevelDetailContentChanged(GlobalNamespace::StandardLevelDetailViewController* levelDetailViewController, GlobalNamespace::StandardLevelDetailViewController::ContentType contentType);
-        void BeatmapLevelSelected(GlobalNamespace::StandardLevelDetailViewController* levelDetailViewController, GlobalNamespace::IDifficultyBeatmap* selectedBeatmap);
-
-        void HandleVanillaLevelWasSelected(GlobalNamespace::IBeatmapLevel* level, GlobalNamespace::IDifficultyBeatmap* difficultyBeatmap);
-        void HandleCustomLevelWasSelected(GlobalNamespace::CustomBeatmapLevel* level, GlobalNamespace::IDifficultyBeatmap* difficultyBeatmap);
+        void LevelWasSelected(LevelSelect::LevelWasSelectedEventArgs const& eventArgs);
 
         bool IsPlayerAllowedToStart();
         void UpdatePlayButtonsState();
 
         /// @brief whether there are any disabling mod infos
         bool _anyDisablingModInfos;
+        bool _levelIsCustom;
+        bool _levelIsWIP;
+        bool _missingRequirements;
         void HandleDisablingModInfosChanged(std::span<PlayButtonInteractable::PlayButtonDisablingModInfo const> disablingModInfos);
 )

--- a/include/UI/RequirementsListManager.hpp
+++ b/include/UI/RequirementsListManager.hpp
@@ -11,6 +11,7 @@
 #include "GlobalNamespace/IDifficultyBeatmap.hpp"
 #include "GlobalNamespace/IBeatmapLevel.hpp"
 
+#include "LevelSelect.hpp"
 #include "Capabilities.hpp"
 #include "IconCache.hpp"
 #include "ColorsOptions.hpp"
@@ -19,27 +20,21 @@
 #include "bsml/shared/BSML/Components/ModalView.hpp"
 
 DECLARE_CLASS_CODEGEN_INTERFACES(SongCore::UI, RequirementsListManager, System::Object, std::vector<Il2CppClass*>({classof(Zenject::IInitializable*), classof(System::IDisposable*)}),
-    DECLARE_CTOR(ctor, GlobalNamespace::StandardLevelDetailViewController* levelDetailViewController, ColorsOptions* colorsOptions, Capabilities* capabilities, IconCache* _iconCache);
+    DECLARE_CTOR(ctor, GlobalNamespace::StandardLevelDetailViewController* levelDetailViewController, ColorsOptions* colorsOptions, Capabilities* capabilities, LevelSelect* levelSelect, IconCache* _iconCache);
 
     DECLARE_INSTANCE_FIELD_PRIVATE(GlobalNamespace::StandardLevelDetailViewController*, _levelDetailViewController);
     DECLARE_INSTANCE_FIELD_PRIVATE(ColorsOptions*, _colorsOptions);
     DECLARE_INSTANCE_FIELD_PRIVATE(Capabilities*, _capabilities);
+    DECLARE_INSTANCE_FIELD_PRIVATE(LevelSelect*, _levelSelect);
     DECLARE_INSTANCE_FIELD_PRIVATE(IconCache*, _iconCache);
-
-    DECLARE_INSTANCE_FIELD_PRIVATE(GlobalNamespace::CustomBeatmapLevel*, _lastSelectedCustomLevel);
-    DECLARE_INSTANCE_FIELD_PRIVATE(GlobalNamespace::IDifficultyBeatmap*, _lastSelectedDifficultyBeatmap);
 
     DECLARE_INSTANCE_FIELD_PRIVATE(UnityEngine::UI::Button*, _requirementButton);
     DECLARE_INSTANCE_FIELD_PRIVATE(BSML::CustomListTableData*, _listTableData);
     DECLARE_INSTANCE_FIELD_PRIVATE(BSML::ModalView*, _requirementModal);
     DECLARE_INSTANCE_FIELD_PRIVATE(System::Action*, _showColorsOnModalHideAction);
+
     DECLARE_INSTANCE_FIELD_PRIVATE(ListW<BSML::CustomCellInfo*>, _requirementsCells);
     DECLARE_INSTANCE_FIELD_PRIVATE(ListW<BSML::CustomCellInfo*>, _unusedRequirementCells);
-
-    using ChangeDifficultyBeatmapAction = System::Action_2<UnityW<GlobalNamespace::StandardLevelDetailViewController>, GlobalNamespace::IDifficultyBeatmap*>;
-    using ChangeContentAction = System::Action_2<UnityW<GlobalNamespace::StandardLevelDetailViewController>, GlobalNamespace::StandardLevelDetailViewController::ContentType>;
-    DECLARE_INSTANCE_FIELD_PRIVATE(ChangeDifficultyBeatmapAction*, _changeDifficultyBeatmapAction);
-    DECLARE_INSTANCE_FIELD_PRIVATE(ChangeContentAction*, _changeContentAction);
 
     DECLARE_OVERRIDE_METHOD_MATCH(void, Initialize, &Zenject::IInitializable::Initialize);
     DECLARE_OVERRIDE_METHOD_MATCH(void, Dispose, &System::IDisposable::Dispose);
@@ -49,18 +44,12 @@ DECLARE_CLASS_CODEGEN_INTERFACES(SongCore::UI, RequirementsListManager, System::
     DECLARE_INSTANCE_METHOD(void, RequirementCellSelected, HMUI::TableView* tableView, int cellIndex);
     DECLARE_INSTANCE_METHOD(ListW<BSML::CustomCellInfo*>, get_requirementsCells);
     private:
-        void LevelDetailContentChanged(GlobalNamespace::StandardLevelDetailViewController* levelDetailViewController, GlobalNamespace::StandardLevelDetailViewController::ContentType contentType);
-        void BeatmapLevelSelected(GlobalNamespace::StandardLevelDetailViewController* levelDetailViewController, GlobalNamespace::IDifficultyBeatmap* selectedBeatmap);
+        BSML::CustomCellInfo* GetCellInfo();
+        void ClearRequirementCells();
+        void UpdateRequirementCells(LevelSelect::LevelWasSelectedEventArgs const& eventArgs);
 
-        void HandleVanillaLevelWasSelected(GlobalNamespace::IBeatmapLevel* level, GlobalNamespace::IDifficultyBeatmap* difficultyBeatmap);
-        void HandleCustomLevelWasSelected(GlobalNamespace::CustomBeatmapLevel* level, GlobalNamespace::IDifficultyBeatmap* difficultyBeatmap);
+        void LevelWasSelected(LevelSelect::LevelWasSelectedEventArgs const& eventArgs);
 
         void ShowColorsOptions();
         void UpdateRequirementButton();
-        void SetRequirementButtonActive(bool active);
-
-        BSML::CustomCellInfo* GetCellInfo();
-        void ClearRequirementCells();
-        void UpdateRequirementCells();
-
 )

--- a/shared/SongCore.hpp
+++ b/shared/SongCore.hpp
@@ -212,6 +212,14 @@ namespace SongCore::API {
         struct SONGCORE_EXPORT LevelWasSelectedEventArgs {
             /// @brief whether this is a custom level. if true, using the custom** in the unions should be valid, if not, you should be using the interfaces
             bool isCustom;
+            /// @brief whether this is a WIP level
+            bool isWIP;
+
+            /// @brief levelID for the level
+            std::string levelID;
+
+            /// @brief optional level hash
+            std::optional<std::string> hash;
 
             struct BasicCustomLevelDetailsGroup {
                 CustomJSONData::CustomLevelInfoSaveData::BasicCustomLevelDetails const& levelDetails;

--- a/src/LevelSelect.cpp
+++ b/src/LevelSelect.cpp
@@ -1,4 +1,5 @@
 #include "LevelSelect.hpp"
+#include "logging.hpp"
 
 #include "CustomJSONData.hpp"
 #include "SongCore.hpp"
@@ -53,7 +54,7 @@ namespace SongCore {
             eventArgs.difficultyBeatmap = GetSelectedDifficultyBeatmap();
             eventArgs.levelID = static_cast<std::string>(eventArgs.previewBeatmapLevel->levelID);
 
-            auto customLevel = il2cpp_utils::try_cast<GlobalNamespace::CustomDifficultyBeatmap>(eventArgs.beatmapLevel).value_or(nullptr);
+            auto customLevel = il2cpp_utils::try_cast<GlobalNamespace::CustomBeatmapLevel>(eventArgs.beatmapLevel).value_or(nullptr);
             if (customLevel) {
                 eventArgs.isCustom = true;
                 HandleCustomLevelWasSelected(eventArgs);
@@ -72,7 +73,7 @@ namespace SongCore {
         eventArgs.difficultyBeatmapSet = GetSelectedDifficultyBeatmapSet();
         eventArgs.difficultyBeatmap = GetSelectedDifficultyBeatmap();
 
-        auto customLevel = il2cpp_utils::try_cast<GlobalNamespace::CustomDifficultyBeatmap>(eventArgs.beatmapLevel).value_or(nullptr);
+        auto customLevel = il2cpp_utils::try_cast<GlobalNamespace::CustomBeatmapLevel>(eventArgs.beatmapLevel).value_or(nullptr);
         if (customLevel) {
             eventArgs.isCustom = true;
             HandleCustomLevelWasSelected(eventArgs);

--- a/src/UI/ColorsOptions.cpp
+++ b/src/UI/ColorsOptions.cpp
@@ -21,18 +21,23 @@ namespace SongCore::UI {
         );
     }
 
-    void ColorsOptions::ShowColors(CustomJSONData::CustomLevelInfoSaveData::BasicCustomDifficultyBeatmapDetails const& details) {
-        if (!_colorsOptionsModal) {
-            BSML::parse_and_construct(Assets::colors_bsml, _levelDetailViewController->_standardLevelDetailView->transform, this);
-        }
+    void ColorsOptions::Show() {
         _colorsOptionsModal->Show();
+    }
+
+    void ColorsOptions::ShowColors(CustomJSONData::CustomLevelInfoSaveData::BasicCustomDifficultyBeatmapDetails const& details) {
+        Parse();
+        Show();
         SetColors(details.customColors.value());
     }
 
-    void ColorsOptions::PostParse() {
-        if (!_selectedColorBG) {
-            WARNING("_selectedColorBG was null in postparse??");
+    void ColorsOptions::Parse() {
+        if (!_colorsOptionsModal) {
+            BSML::parse_and_construct(Assets::colors_bsml, _levelDetailViewController->_standardLevelDetailView->transform, this);
         }
+    }
+
+    void ColorsOptions::PostParse() {
         auto colorSchemeViewPrefab = UnityEngine::Resources::FindObjectsOfTypeAll<GlobalNamespace::ColorSchemeView*>()->First();
         auto colorSchemeViewObject = UnityEngine::Object::Instantiate(colorSchemeViewPrefab->gameObject, _selectedColorBG);
         _colorSchemeView = colorSchemeViewObject->GetComponent<GlobalNamespace::ColorSchemeView*>();

--- a/src/UI/DeleteLevelButton.cpp
+++ b/src/UI/DeleteLevelButton.cpp
@@ -85,6 +85,8 @@ namespace SongCore::UI {
         _lastSelectedDifficultyBeatmap = eventArgs.difficultyBeatmap;
         if (eventArgs.isCustom) {
             _lastSelectedCustomLevel = eventArgs.customBeatmapLevel;
+        } else {
+            _lastSelectedCustomLevel = nullptr;
         }
         UpdateButtonState();
     }

--- a/src/UI/PlayButtonsUpdater.cpp
+++ b/src/UI/PlayButtonsUpdater.cpp
@@ -1,5 +1,6 @@
 #include "UI/PlayButtonsUpdater.hpp"
 #include "CustomJSONData.hpp"
+#include "LevelSelect.hpp"
 #include "logging.hpp"
 
 #include "GlobalNamespace/IDifficultyBeatmapSet.hpp"
@@ -12,10 +13,11 @@
 DEFINE_TYPE(SongCore::UI, PlayButtonsUpdater);
 
 namespace SongCore::UI {
-    void PlayButtonsUpdater::ctor(GlobalNamespace::StandardLevelDetailViewController* levelDetailViewController,  PlayButtonInteractable* playButtonInteractable, Capabilities* capabilities) {
+    void PlayButtonsUpdater::ctor(GlobalNamespace::StandardLevelDetailViewController* levelDetailViewController,  PlayButtonInteractable* playButtonInteractable, Capabilities* capabilities, LevelSelect* levelSelect) {
         _levelDetailViewController = levelDetailViewController;
         _playButtonInteractable;
         _capabilities = capabilities;
+        _levelSelect = levelSelect;
     }
 
     void PlayButtonsUpdater::Initialize() {
@@ -23,126 +25,44 @@ namespace SongCore::UI {
         _practiceButton = _levelDetailViewController->_standardLevelDetailView->practiceButton;
         _anyDisablingModInfos = !_playButtonInteractable->PlayButtonDisablingModInfos.empty();
 
-        _changeDifficultyBeatmapAction = BSML::MakeSystemAction<UnityW<GlobalNamespace::StandardLevelDetailViewController>, GlobalNamespace::IDifficultyBeatmap*>(
-            std::function<void(UnityW<GlobalNamespace::StandardLevelDetailViewController>, GlobalNamespace::IDifficultyBeatmap*)>(
-                std::bind(&PlayButtonsUpdater::BeatmapLevelSelected, this, std::placeholders::_1, std::placeholders::_2)
-            )
-        );
-
-        _levelDetailViewController->add_didChangeDifficultyBeatmapEvent(_changeDifficultyBeatmapAction);
-
-        _changeContentAction = BSML::MakeSystemAction<UnityW<GlobalNamespace::StandardLevelDetailViewController>, GlobalNamespace::StandardLevelDetailViewController::ContentType>(
-            std::function<void(UnityW<GlobalNamespace::StandardLevelDetailViewController>, GlobalNamespace::StandardLevelDetailViewController::ContentType)>(
-                std::bind(&PlayButtonsUpdater::LevelDetailContentChanged, this, std::placeholders::_1, std::placeholders::_2)
-            )
-        );
-
-        _levelDetailViewController->add_didChangeContentEvent(_changeContentAction);
+        _levelSelect->LevelWasSelected += {&PlayButtonsUpdater::LevelWasSelected, this};
     }
 
     void PlayButtonsUpdater::Dispose() {
-        _levelDetailViewController->remove_didChangeDifficultyBeatmapEvent(_changeDifficultyBeatmapAction);
-        _levelDetailViewController->remove_didChangeContentEvent(_changeContentAction);
-    }
-
-    std::u16string_view DiffToStringView(GlobalNamespace::BeatmapDifficulty diff) {
-        switch (diff) {
-            case GlobalNamespace::BeatmapDifficulty::Easy:
-                return u"Easy";
-            case GlobalNamespace::BeatmapDifficulty::Normal:
-                return u"Normal";
-            case GlobalNamespace::BeatmapDifficulty::Hard:
-                return u"Hard";
-            case GlobalNamespace::BeatmapDifficulty::Expert:
-                return u"Expert";
-            case GlobalNamespace::BeatmapDifficulty::ExpertPlus:
-                return u"ExpertPlus";
-        }
-        return u"Unknown";
+        _levelSelect->LevelWasSelected -= {&PlayButtonsUpdater::LevelWasSelected, this};
     }
 
     bool PlayButtonsUpdater::IsPlayerAllowedToStart() {
         if (_anyDisablingModInfos) return false;
-        if (!_lastSelectedDifficultyBeatmap) return false;
-        if (!_lastSelectedCustomLevel) return true;
-
-        // TODO: get requirements from the selected difficulty beatmap
-        // use diff and characteristic to get the correct customData from the saveData & read requirements from there
-        auto saveData = il2cpp_utils::cast<CustomJSONData::CustomLevelInfoSaveData>(_lastSelectedCustomLevel->standardLevelInfoSaveData);
-        auto diff = _lastSelectedDifficultyBeatmap->get_difficulty();
-        auto characteristic = _lastSelectedDifficultyBeatmap->parentDifficultyBeatmapSet->get_beatmapCharacteristic();
-
-        auto levelDetailsOpt = saveData->TryGetBasicLevelDetails();
-        if (!levelDetailsOpt.has_value()) return true;
-
-        auto& levelDetails = levelDetailsOpt->get();
-        auto difficultyBeatmapDetailsOpt = levelDetails.TryGetCharacteristicAndDifficulty(characteristic->serializedName, diff);
-        if (!difficultyBeatmapDetailsOpt.has_value()) return true;
-
-        auto& difficultyBeatmapDetails = difficultyBeatmapDetailsOpt->get();
-
-        for (auto& requirement : difficultyBeatmapDetails.requirements) {
-            if (!_capabilities->IsCapabilityRegistered(requirement)) return false;
-        }
+        if (!_levelIsCustom) return true;
+        if (_missingRequirements) return false;
 
         return true;
     }
 
     void PlayButtonsUpdater::UpdatePlayButtonsState() {
         auto interactable = IsPlayerAllowedToStart();
-        auto isCustom = _lastSelectedCustomLevel != nullptr;
-        auto isWip = isCustom && _lastSelectedCustomLevel->levelID.ends_with(u" WIP");
 
         // if we allow player to start at all, practice button is enabled
         _practiceButton->set_interactable(interactable);
         // we want it to be "allow to start" and "not wip"
-        _playButton->set_interactable(interactable && !isWip);
+        _playButton->set_interactable(interactable && !_levelIsWIP);
     }
 
-    void PlayButtonsUpdater::LevelDetailContentChanged(GlobalNamespace::StandardLevelDetailViewController* viewController, GlobalNamespace::StandardLevelDetailViewController::ContentType contentType) {
-        if (contentType == GlobalNamespace::StandardLevelDetailViewController::ContentType::OwnedAndReady) {
-            auto difficultyBeatmap = viewController->selectedDifficultyBeatmap;
-            _lastSelectedDifficultyBeatmap = difficultyBeatmap;
-            _lastSelectedCustomLevel = nullptr;
-            if (!difficultyBeatmap) return;
+    void PlayButtonsUpdater::LevelWasSelected(LevelSelect::LevelWasSelectedEventArgs const& eventArgs) {
+        _levelIsCustom = eventArgs.isCustom;
+        _levelIsWIP = eventArgs.isWIP;
 
-            auto beatmapLevel = difficultyBeatmap->level;
-            auto customBeatmapLevel = il2cpp_utils::try_cast<GlobalNamespace::CustomBeatmapLevel>(beatmapLevel).value_or(nullptr);
-
-            if (customBeatmapLevel) { // custom level
-                HandleCustomLevelWasSelected(customBeatmapLevel, difficultyBeatmap);
-            } else { // vanilla level
-                HandleVanillaLevelWasSelected(beatmapLevel, difficultyBeatmap);
+        _missingRequirements = false;
+        if (eventArgs.customLevelDetails.has_value()) {
+            for (auto& requirement : eventArgs.customLevelDetails->difficultyDetails.requirements) {
+                if (!_capabilities->IsCapabilityRegistered(requirement)) {
+                    _missingRequirements = true;
+                    break;
+                }
             }
         }
-    }
 
-    void PlayButtonsUpdater::BeatmapLevelSelected(GlobalNamespace::StandardLevelDetailViewController* _, GlobalNamespace::IDifficultyBeatmap* difficultyBeatmap) {
-        DEBUG("Something was selected!");
-        _lastSelectedDifficultyBeatmap = difficultyBeatmap;
-        _lastSelectedCustomLevel = nullptr;
-        if (!difficultyBeatmap) return;
-
-        auto beatmapLevel = difficultyBeatmap->level;
-        auto customBeatmapLevel = il2cpp_utils::try_cast<GlobalNamespace::CustomBeatmapLevel>(beatmapLevel).value_or(nullptr);
-        DEBUG("LevelID {} was selected", difficultyBeatmap->level->i___GlobalNamespace__IPreviewBeatmapLevel()->get_levelID());
-
-        if (customBeatmapLevel) {
-            HandleCustomLevelWasSelected(customBeatmapLevel, difficultyBeatmap);
-        } else { // not a custom level
-            HandleVanillaLevelWasSelected(beatmapLevel, difficultyBeatmap);
-        }
-    }
-
-    void PlayButtonsUpdater::HandleVanillaLevelWasSelected(GlobalNamespace::IBeatmapLevel* level, GlobalNamespace::IDifficultyBeatmap* difficultyBeatmap) {
-        _lastSelectedDifficultyBeatmap = difficultyBeatmap;
-        _lastSelectedCustomLevel = nullptr;
-        UpdatePlayButtonsState();
-    }
-
-    void PlayButtonsUpdater::HandleCustomLevelWasSelected(GlobalNamespace::CustomBeatmapLevel* level, GlobalNamespace::IDifficultyBeatmap* difficultyBeatmap) {
-        _lastSelectedDifficultyBeatmap = difficultyBeatmap;
-        _lastSelectedCustomLevel = level;
         UpdatePlayButtonsState();
     }
 


### PR DESCRIPTION
 - Requirements list now uses `SongCore::LevelSelect` events to know what was selected
 - Play button managing now uses `SongCore::LevelSelect` events to know whether the play button should be enabled
 - Fixes a bug in the LevelSelect code that would cause levels to never appear as custom