### PR TITLE
[Fix customs list update] Implementing better reloading of the song list when a refresh happens

### DIFF
--- a/include/SongLoader/NavigationControllerUpdater.hpp
+++ b/include/SongLoader/NavigationControllerUpdater.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "SongLoader/CustomBeatmapLevel.hpp"
 #include "SongLoader/CustomBeatmapLevelsRepository.hpp"
 #include "custom-types/shared/macros.hpp"
 #include "System/Object.hpp"
@@ -8,6 +9,7 @@
 #include "GlobalNamespace/LevelFilteringNavigationController.hpp"
 #include "GlobalNamespace/LevelCollectionViewController.hpp"
 #include "GlobalNamespace/LevelCollectionNavigationController.hpp"
+#include "GlobalNamespace/SelectLevelCategoryViewController.hpp"
 #include "GlobalNamespace/BeatmapLevelsModel.hpp"
 #include "SongLoader/RuntimeSongLoader.hpp"
 #include <vector>
@@ -22,9 +24,13 @@ DECLARE_CLASS_CODEGEN_INTERFACES(SongCore::SongLoader, NavigationControllerUpdat
     DECLARE_INSTANCE_FIELD_PRIVATE(GlobalNamespace::LevelCollectionNavigationController*, _levelCollectionNavigationController);
     DECLARE_INSTANCE_FIELD_PRIVATE(GlobalNamespace::LevelCollectionViewController*, _levelCollectionViewController);
 
+    DECLARE_INSTANCE_FIELD_PRIVATE(StringW, _lastSelectedBeatmapLevelId);
+    DECLARE_INSTANCE_FIELD_PRIVATE(StringW, _lastSelectedPackId);
+    DECLARE_INSTANCE_FIELD_PRIVATE(GlobalNamespace::SelectLevelCategoryViewController::LevelCategory, _lastSelectedCategory);
+
     DECLARE_CTOR(ctor, GlobalNamespace::BeatmapLevelsModel* beatmapLevelsModel, RuntimeSongLoader* runtimeSongLoader, GlobalNamespace::LevelFilteringNavigationController* levelFilteringNavigationController, GlobalNamespace::LevelCollectionNavigationController* levelCollectionNavigationViewController, GlobalNamespace::LevelCollectionViewController* levelCollectionViewController);
 
     private:
         void SongsWillRefresh();
-        void CustomLevelPacksRefreshed(CustomBeatmapLevelsRepository* levelsRepository);
+        void SongsLoaded(std::span<SongLoader::CustomBeatmapLevel* const> levels);
 )


### PR DESCRIPTION
- Shifts around when SongsWillRefresh happens so that it's possible to call certain functions in a way that they can await the refresh through checking "AreSongsRefreshing" started from the songswillrefresh call
- Rework the NavigationControllerUpdater so a call to a specific method doesn't crash anymore and instead awaits in an async fashion