### PR TITLE
Fix environment name mismatch

### DIFF
--- a/include/Utils/Hashing.hpp
+++ b/include/Utils/Hashing.hpp
@@ -3,7 +3,7 @@
 #include "CustomJSONData.hpp"
 
 namespace SongCore::Utils {
-    std::optional<std::string> GetCustomLevelHash(std::filesystem::path const& levelPath, SongCore::CustomJSONData::CustomLevelInfoSaveData* saveData);
-    std::optional<std::string> GetCustomLevelHash(std::filesystem::path const& levelPath, SongCore::CustomJSONData::CustomBeatmapLevelSaveData* saveData);
+    std::optional<std::string> GetCustomLevelHash(std::filesystem::path const& levelPath, SongCore::CustomJSONData::CustomLevelInfoSaveDataV2* saveData);
+    std::optional<std::string> GetCustomLevelHash(std::filesystem::path const& levelPath, SongCore::CustomJSONData::CustomBeatmapLevelSaveDataV4* saveData);
     std::optional<int> GetDirectoryHash(std::filesystem::path const& directoryPath);
 }

--- a/shared/CustomJSONData.hpp
+++ b/shared/CustomJSONData.hpp
@@ -243,7 +243,7 @@ namespace SongCore::CustomJSONData {
 }
 
 // V2 | V3
-DECLARE_CLASS_CODEGEN(SongCore::CustomJSONData, CustomLevelInfoSaveDataV3, GlobalNamespace::StandardLevelInfoSaveData,
+DECLARE_CLASS_CODEGEN(SongCore::CustomJSONData, CustomLevelInfoSaveDataV2, GlobalNamespace::StandardLevelInfoSaveData,
 
 		DECLARE_CTOR(ctor,
 			StringW songName,

--- a/shared/CustomJSONData.hpp
+++ b/shared/CustomJSONData.hpp
@@ -242,8 +242,8 @@ namespace SongCore::CustomJSONData {
 	};
 }
 
-// V2
-DECLARE_CLASS_CODEGEN(SongCore::CustomJSONData, CustomLevelInfoSaveData, GlobalNamespace::StandardLevelInfoSaveData,
+// V2 | V3
+DECLARE_CLASS_CODEGEN(SongCore::CustomJSONData, CustomLevelInfoSaveDataV3, GlobalNamespace::StandardLevelInfoSaveData,
 
 		DECLARE_CTOR(ctor,
 			StringW songName,
@@ -304,7 +304,7 @@ DECLARE_CLASS_CODEGEN(SongCore::CustomJSONData, CustomDifficultyBeatmap, GlobalN
 )
 
 // V4
-DECLARE_CLASS_CODEGEN(SongCore::CustomJSONData, CustomBeatmapLevelSaveData, BeatmapLevelSaveDataVersion4::BeatmapLevelSaveData,
+DECLARE_CLASS_CODEGEN(SongCore::CustomJSONData, CustomBeatmapLevelSaveDataV4, BeatmapLevelSaveDataVersion4::BeatmapLevelSaveData,
 
 	//Manually assign fields
 	DECLARE_CTOR(ctor);

--- a/shared/SongCore.hpp
+++ b/shared/SongCore.hpp
@@ -224,10 +224,10 @@ namespace SongCore::API {
             };
 
             /// @brief if this is a V2-V3 custom level, this should be set
-            std::optional<CustomJSONData::CustomLevelInfoSaveData*> customLevelInfoSaveDataV2 = std::nullopt;
+            std::optional<CustomJSONData::CustomLevelInfoSaveDataV2*> customLevelInfoSaveDataV2 = std::nullopt;
 
             /// @brief if this is a V4 custom level, this should be set
-            std::optional<CustomJSONData::CustomBeatmapLevelSaveData*> customBeatmapLevelSaveDataV4 = std::nullopt;
+            std::optional<CustomJSONData::CustomBeatmapLevelSaveDataV4*> customBeatmapLevelSaveDataV4 = std::nullopt;
 
             /// @brief if this is a custom level, this should be set
             std::optional<BasicCustomLevelDetailsGroup> customLevelDetails = std::nullopt;

--- a/shared/SongLoader/CustomBeatmapLevel.hpp
+++ b/shared/SongLoader/CustomBeatmapLevel.hpp
@@ -40,12 +40,12 @@ DECLARE_CLASS_CODEGEN(SongCore::SongLoader, CustomBeatmapLevel, GlobalNamespace:
         __declspec(property(get=get_CustomSaveDataInfo)) std::optional<std::reference_wrapper<CustomJSONData::CustomSaveDataInfo>> CustomSaveDataInfo;
 
         /// @brief level info.dat save data. Set for V2-V3 levels.
-        std::optional<CustomJSONData::CustomLevelInfoSaveData*> get_standardLevelInfoSaveDataV2() { return _customLevelSaveDataV2 ? std::optional(_customLevelSaveDataV2) : std::nullopt; }
-        __declspec(property(get=get_standardLevelInfoSaveDataV2)) std::optional<CustomJSONData::CustomLevelInfoSaveData*> standardLevelInfoSaveDataV2;
+        std::optional<CustomJSONData::CustomLevelInfoSaveDataV2*> get_standardLevelInfoSaveDataV2() { return _customLevelSaveDataV2 ? std::optional(_customLevelSaveDataV2) : std::nullopt; }
+        __declspec(property(get=get_standardLevelInfoSaveDataV2)) std::optional<CustomJSONData::CustomLevelInfoSaveDataV2*> standardLevelInfoSaveDataV2;
 
         /// @brief level info.dat save data. Set for V4 levels.
-        std::optional<CustomJSONData::CustomBeatmapLevelSaveData*> get_beatmapLevelSaveDataV4() { return _customBeatmapLevelSaveDataV4 ? std::optional(_customBeatmapLevelSaveDataV4) : std::nullopt; }
-        __declspec(property(get=get_beatmapLevelSaveDataV4)) std::optional<CustomJSONData::CustomBeatmapLevelSaveData*> beatmapLevelSaveDataV4;
+        std::optional<CustomJSONData::CustomBeatmapLevelSaveDataV4*> get_beatmapLevelSaveDataV4() { return _customBeatmapLevelSaveDataV4 ? std::optional(_customBeatmapLevelSaveDataV4) : std::nullopt; }
+        __declspec(property(get=get_beatmapLevelSaveDataV4)) std::optional<CustomJSONData::CustomBeatmapLevelSaveDataV4*> beatmapLevelSaveDataV4;
 
         /// @brief level beatmapleveldata
         GlobalNamespace::IBeatmapLevelData* get_beatmapLevelData() const { return _beatmapLevelData; }
@@ -53,9 +53,10 @@ DECLARE_CLASS_CODEGEN(SongCore::SongLoader, CustomBeatmapLevel, GlobalNamespace:
 
         static CustomBeatmapLevel* New(
             std::string_view customLevelPath,
-            CustomJSONData::CustomLevelInfoSaveData* saveDataV2,
-            CustomJSONData::CustomBeatmapLevelSaveData* saveDataV4,
+            CustomJSONData::CustomLevelInfoSaveDataV2* saveDataV2,
+            CustomJSONData::CustomBeatmapLevelSaveDataV4* saveDataV4,
             GlobalNamespace::IBeatmapLevelData* beatmapLevelData,
+            // BeatmapLevelData args
             bool hasPrecalculatedData,
             ::StringW levelID,
             ::StringW songName,
@@ -74,8 +75,8 @@ DECLARE_CLASS_CODEGEN(SongCore::SongLoader, CustomBeatmapLevel, GlobalNamespace:
             ::System::Collections::Generic::IReadOnlyDictionary_2<::System::ValueTuple_2<::UnityW<::GlobalNamespace::BeatmapCharacteristicSO>, ::GlobalNamespace::BeatmapDifficulty>, ::GlobalNamespace::BeatmapBasicData*>* beatmapBasicData
         );
     private:
-        CustomJSONData::CustomLevelInfoSaveData* _customLevelSaveDataV2;
-        CustomJSONData::CustomBeatmapLevelSaveData* _customBeatmapLevelSaveDataV4;
+        CustomJSONData::CustomLevelInfoSaveDataV2* _customLevelSaveDataV2;
+        CustomJSONData::CustomBeatmapLevelSaveDataV4* _customBeatmapLevelSaveDataV4;
         GlobalNamespace::IBeatmapLevelData* _beatmapLevelData;
         std::string _customLevelPath;
 )

--- a/shared/SongLoader/LevelLoader.hpp
+++ b/shared/SongLoader/LevelLoader.hpp
@@ -32,13 +32,13 @@ DECLARE_CLASS_CODEGEN(SongCore::SongLoader, LevelLoader, System::Object,
     public:
         /// @brief gets the v3 savedata from the path
         [[deprecated("Use GetSaveDataFromV3 instead, this just redirects to that")]]
-        SongCore::CustomJSONData::CustomLevelInfoSaveData* GetStandardSaveData(std::filesystem::path const& path);
+        SongCore::CustomJSONData::CustomLevelInfoSaveDataV2* GetStandardSaveData(std::filesystem::path const& path);
 
         /// @brief gets the v3 savedata from the path
-        SongCore::CustomJSONData::CustomLevelInfoSaveData* GetSaveDataFromV3(std::filesystem::path const& path);
+        SongCore::CustomJSONData::CustomLevelInfoSaveDataV2* GetSaveDataFromV3(std::filesystem::path const& path);
 
         /// @brief gets the v4 savedata from the path
-        SongCore::CustomJSONData::CustomBeatmapLevelSaveData* GetSaveDataFromV4(std::filesystem::path const& path);
+        SongCore::CustomJSONData::CustomBeatmapLevelSaveDataV4* GetSaveDataFromV4(std::filesystem::path const& path);
 
         /// @brief Loads song at given path
         /// @param path the path to the song
@@ -46,21 +46,21 @@ DECLARE_CLASS_CODEGEN(SongCore::SongLoader, LevelLoader, System::Object,
         /// @param saveData the level save data, for custom levels this is always a custom level info savedata
         /// @param outHash output for the hash of this level, might be unneeded though
         /// @return loaded beatmap level, or nullptr if failed
-        CustomBeatmapLevel* LoadCustomBeatmapLevel(std::filesystem::path const& levelPath, bool wip, SongCore::CustomJSONData::CustomLevelInfoSaveData* saveData, std::string& hashOut);
+        CustomBeatmapLevel* LoadCustomBeatmapLevel(std::filesystem::path const& levelPath, bool wip, SongCore::CustomJSONData::CustomLevelInfoSaveDataV2* saveData, std::string& hashOut);
 
         /// @brief Loads song at given path
         /// @param path the path to the song
         /// @param isWip is this a wip song
-        /// @param saveData the level save data, for v4 levels this is a CustomBeatmapLevelSaveData
+        /// @param saveData the level save data, for v4 levels this is a CustomBeatmapLevelSaveDataV4
         /// @param outHash output for the hash of this level, might be unneeded though
         /// @return loaded beatmap level, or nullptr if failed
-        CustomBeatmapLevel* LoadCustomBeatmapLevel(std::filesystem::path const& levelPath, bool wip, SongCore::CustomJSONData::CustomBeatmapLevelSaveData* saveData, std::string& hashOut);
+        CustomBeatmapLevel* LoadCustomBeatmapLevel(std::filesystem::path const& levelPath, bool wip, SongCore::CustomJSONData::CustomBeatmapLevelSaveDataV4* saveData, std::string& hashOut);
 
     private:
         /// @brief does basic verification on a map to catch any problems before they actually occur
-        bool BasicVerifyMap(std::filesystem::path const& levelPath, SongCore::CustomJSONData::CustomLevelInfoSaveData* saveData);
+        bool BasicVerifyMap(std::filesystem::path const& levelPath, SongCore::CustomJSONData::CustomLevelInfoSaveDataV2* saveData);
         /// @brief does basic verification on a map to catch any problems before they actually occur
-        bool BasicVerifyMap(std::filesystem::path const& levelPath, SongCore::CustomJSONData::CustomBeatmapLevelSaveData* saveData);
+        bool BasicVerifyMap(std::filesystem::path const& levelPath, SongCore::CustomJSONData::CustomBeatmapLevelSaveDataV4* saveData);
 
         using CharacteristicDifficultyPair = System::ValueTuple_2<UnityW<GlobalNamespace::BeatmapCharacteristicSO>, GlobalNamespace::BeatmapDifficulty>;
         using BeatmapBasicDataDict = System::Collections::Generic::Dictionary_2<CharacteristicDifficultyPair, GlobalNamespace::BeatmapBasicData*>;
@@ -70,10 +70,10 @@ DECLARE_CLASS_CODEGEN(SongCore::SongLoader, LevelLoader, System::Object,
         GlobalNamespace::FileSystemPreviewMediaData* GetPreviewMediaData(std::filesystem::path const& levelPath, StringW coverImageFilename, StringW songFilename);
 
         /// @brief beatmap level data from filesystem & basic beatmap data from savedata
-        std::pair<GlobalNamespace::FileSystemBeatmapLevelData*, BeatmapBasicDataDict*> GetBeatmapLevelAndBasicData(std::filesystem::path const& levelPath, std::string_view levelID, std::span<GlobalNamespace::EnvironmentName const> environmentNames, std::span<GlobalNamespace::ColorScheme* const> colorSchemes, CustomJSONData::CustomLevelInfoSaveData* saveData);
+        std::pair<GlobalNamespace::FileSystemBeatmapLevelData*, BeatmapBasicDataDict*> GetBeatmapLevelAndBasicData(std::filesystem::path const& levelPath, std::string_view levelID, std::span<GlobalNamespace::EnvironmentName const> environmentNames, std::span<GlobalNamespace::ColorScheme* const> colorSchemes, CustomJSONData::CustomLevelInfoSaveDataV2* saveData);
 
         /// @brief beatmap level data from filesystem & basic beatmap data from savedata
-        std::pair<GlobalNamespace::FileSystemBeatmapLevelData*, BeatmapBasicDataDict*> GetBeatmapLevelAndBasicData(std::filesystem::path const& levelPath, std::string_view levelID, CustomJSONData::CustomBeatmapLevelSaveData* saveData);
+        std::pair<GlobalNamespace::FileSystemBeatmapLevelData*, BeatmapBasicDataDict*> GetBeatmapLevelAndBasicData(std::filesystem::path const& levelPath, std::string_view levelID, CustomJSONData::CustomBeatmapLevelSaveDataV4* saveData);
 
         /// @brief gets the environment info for the environmentName and whether it's all directions or not
         GlobalNamespace::EnvironmentInfoSO* GetEnvironmentInfo(StringW environmentName, bool allDirections);
@@ -85,20 +85,20 @@ DECLARE_CLASS_CODEGEN(SongCore::SongLoader, LevelLoader, System::Object,
         ArrayW<GlobalNamespace::ColorScheme*> GetColorSchemes(std::span<GlobalNamespace::BeatmapLevelColorSchemeSaveData* const> colorSchemeDatas);
 
         /// @brief gets the length for a level
-        static float GetLengthForLevel(std::filesystem::path const& levelPath, CustomJSONData::CustomLevelInfoSaveData* saveData);
+        static float GetLengthForLevel(std::filesystem::path const& levelPath, CustomJSONData::CustomLevelInfoSaveDataV2* saveData);
 
         /// @brief gets the length for a level
-        static float GetLengthForLevel(std::filesystem::path const& levelPath, CustomJSONData::CustomBeatmapLevelSaveData* saveData);
+        static float GetLengthForLevel(std::filesystem::path const& levelPath, CustomJSONData::CustomBeatmapLevelSaveDataV4* saveData);
 
         /// @brief calculates the song duration by parsing the first characteristic, first difficulty for the last note and seeing the time on it
-        static float GetLengthFromMap(std::filesystem::path const& levelPath, CustomJSONData::CustomLevelInfoSaveData* saveData);
+        static float GetLengthFromMap(std::filesystem::path const& levelPath, CustomJSONData::CustomLevelInfoSaveDataV2* saveData);
 
         /// @brief calculates the song duration by parsing the first characteristic, first difficulty for the last note and seeing the time on it
-        static float GetLengthFromMap(std::filesystem::path const& levelPath, CustomJSONData::CustomBeatmapLevelSaveData* saveData);
+        static float GetLengthFromMap(std::filesystem::path const& levelPath, CustomJSONData::CustomBeatmapLevelSaveDataV4* saveData);
 
         /// @brief gets the v3 savedata with custom data from the base game save data
-        SongCore::CustomJSONData::CustomLevelInfoSaveData* LoadCustomSaveData(GlobalNamespace::StandardLevelInfoSaveData* saveData, std::u16string_view stringData);
+        SongCore::CustomJSONData::CustomLevelInfoSaveDataV2* LoadCustomSaveData(GlobalNamespace::StandardLevelInfoSaveData* saveData, std::u16string_view stringData);
 
         /// @brief gets the v4 savedata with custom data from the base game save data
-        SongCore::CustomJSONData::CustomBeatmapLevelSaveData* LoadCustomSaveData(BeatmapLevelSaveDataVersion4::BeatmapLevelSaveData* saveData, std::u16string_view stringData);
+        SongCore::CustomJSONData::CustomBeatmapLevelSaveDataV4* LoadCustomSaveData(BeatmapLevelSaveDataVersion4::BeatmapLevelSaveData* saveData, std::u16string_view stringData);
 )

--- a/shared/SongLoader/LevelLoader.hpp
+++ b/shared/SongLoader/LevelLoader.hpp
@@ -97,8 +97,8 @@ DECLARE_CLASS_CODEGEN(SongCore::SongLoader, LevelLoader, System::Object,
         static float GetLengthFromMap(std::filesystem::path const& levelPath, CustomJSONData::CustomBeatmapLevelSaveData* saveData);
 
         /// @brief gets the v3 savedata with custom data from the base game save data
-        SongCore::CustomJSONData::CustomLevelInfoSaveData* LoadCustomSaveData(GlobalNamespace::StandardLevelInfoSaveData* saveData, std::u16string const& stringData);
+        SongCore::CustomJSONData::CustomLevelInfoSaveData* LoadCustomSaveData(GlobalNamespace::StandardLevelInfoSaveData* saveData, std::u16string_view stringData);
 
         /// @brief gets the v4 savedata with custom data from the base game save data
-        SongCore::CustomJSONData::CustomBeatmapLevelSaveData* LoadCustomSaveData(BeatmapLevelSaveDataVersion4::BeatmapLevelSaveData* saveData, std::u16string const& stringData);
+        SongCore::CustomJSONData::CustomBeatmapLevelSaveData* LoadCustomSaveData(BeatmapLevelSaveDataVersion4::BeatmapLevelSaveData* saveData, std::u16string_view stringData);
 )

--- a/src/CustomJSONData.cpp
+++ b/src/CustomJSONData.cpp
@@ -6,12 +6,12 @@
 
 using namespace GlobalNamespace;
 
-//V2
+//V2 | V3
 DEFINE_TYPE(SongCore::CustomJSONData, CustomLevelInfoSaveData);
 DEFINE_TYPE(SongCore::CustomJSONData, CustomDifficultyBeatmapSet);
 DEFINE_TYPE(SongCore::CustomJSONData, CustomDifficultyBeatmap);
 
-//V3
+//V4
 DEFINE_TYPE(SongCore::CustomJSONData, CustomBeatmapLevelSaveData);
 DEFINE_TYPE(SongCore::CustomJSONData, CustomDifficultyBeatmapV4);
 

--- a/src/CustomJSONData.cpp
+++ b/src/CustomJSONData.cpp
@@ -7,17 +7,17 @@
 using namespace GlobalNamespace;
 
 //V2 | V3
-DEFINE_TYPE(SongCore::CustomJSONData, CustomLevelInfoSaveData);
+DEFINE_TYPE(SongCore::CustomJSONData, CustomLevelInfoSaveDataV2);
 DEFINE_TYPE(SongCore::CustomJSONData, CustomDifficultyBeatmapSet);
 DEFINE_TYPE(SongCore::CustomJSONData, CustomDifficultyBeatmap);
 
 //V4
-DEFINE_TYPE(SongCore::CustomJSONData, CustomBeatmapLevelSaveData);
+DEFINE_TYPE(SongCore::CustomJSONData, CustomBeatmapLevelSaveDataV4);
 DEFINE_TYPE(SongCore::CustomJSONData, CustomDifficultyBeatmapV4);
 
 namespace SongCore::CustomJSONData {
 
-	void CustomLevelInfoSaveData::ctor(
+	void CustomLevelInfoSaveDataV2::ctor(
 		StringW songName,
 		StringW songSubName,
 		StringW songAuthorName,
@@ -516,7 +516,7 @@ void CustomDifficultyBeatmap::ctor(
 	);
 }
 
-void CustomBeatmapLevelSaveData::ctor() {
+void CustomBeatmapLevelSaveDataV4::ctor() {
 	INVOKE_CTOR();
 
 	_ctor();

--- a/src/SongLoader/CustomBeatmapLevel.cpp
+++ b/src/SongLoader/CustomBeatmapLevel.cpp
@@ -46,8 +46,8 @@ namespace SongCore::SongLoader {
 
     CustomBeatmapLevel* CustomBeatmapLevel::New(
         std::string_view customLevelPath,
-        CustomJSONData::CustomLevelInfoSaveData* saveDataV2,
-        CustomJSONData::CustomBeatmapLevelSaveData* saveDataV4,
+        CustomJSONData::CustomLevelInfoSaveDataV2* saveDataV2,
+        CustomJSONData::CustomBeatmapLevelSaveDataV4* saveDataV4,
         GlobalNamespace::IBeatmapLevelData* beatmapLevelData,
         bool hasPrecalculatedData,
         ::StringW levelID,

--- a/src/SongLoader/LevelLoader.cpp
+++ b/src/SongLoader/LevelLoader.cpp
@@ -35,6 +35,7 @@
 #include <exception>
 #include <filesystem>
 #include <fmt/core.h>
+#include <fmt/ranges.h>
 #include <limits>
 
 DEFINE_TYPE(SongCore::SongLoader, LevelLoader);
@@ -51,11 +52,11 @@ namespace SongCore::SongLoader {
         _clipLoader = GlobalNamespace::AudioClipAsyncLoader::CreateDefault();
     }
 
-    SongCore::CustomJSONData::CustomLevelInfoSaveData* LevelLoader::GetStandardSaveData(std::filesystem::path const& path) {
+    SongCore::CustomJSONData::CustomLevelInfoSaveDataV2* LevelLoader::GetStandardSaveData(std::filesystem::path const& path) {
         return GetSaveDataFromV3(path);
     }
 
-    SongCore::CustomJSONData::CustomLevelInfoSaveData* LevelLoader::GetSaveDataFromV3(std::filesystem::path const& path) {
+    SongCore::CustomJSONData::CustomLevelInfoSaveDataV2* LevelLoader::GetSaveDataFromV3(std::filesystem::path const& path) {
         if (path.empty()) {
             ERROR("Provided path was empty!");
             return nullptr;
@@ -79,9 +80,9 @@ namespace SongCore::SongLoader {
                 return nullptr;
             }
 
-            auto opt = il2cpp_utils::try_cast<SongCore::CustomJSONData::CustomLevelInfoSaveData>(standardSaveData);
+            auto opt = il2cpp_utils::try_cast<SongCore::CustomJSONData::CustomLevelInfoSaveDataV2>(standardSaveData);
             if (!opt.has_value()) {
-                ERROR("Cannot load file {} as CustomLevelInfoSaveData!", path.string());
+                ERROR("Cannot load file {} as CustomLevelInfoSaveDataV2!", path.string());
                 return nullptr;
             }
 
@@ -94,7 +95,7 @@ namespace SongCore::SongLoader {
         return nullptr;
     }
 
-    SongCore::CustomJSONData::CustomBeatmapLevelSaveData* LevelLoader::GetSaveDataFromV4(std::filesystem::path const& path) {
+    SongCore::CustomJSONData::CustomBeatmapLevelSaveDataV4* LevelLoader::GetSaveDataFromV4(std::filesystem::path const& path) {
         if (path.empty()) {
             ERROR("Provided path was empty!");
             return nullptr;
@@ -118,9 +119,9 @@ namespace SongCore::SongLoader {
                 return nullptr;
             }
 
-            auto opt = il2cpp_utils::try_cast<SongCore::CustomJSONData::CustomBeatmapLevelSaveData>(beatmapLevelSaveData);
+            auto opt = il2cpp_utils::try_cast<SongCore::CustomJSONData::CustomBeatmapLevelSaveDataV4>(beatmapLevelSaveData);
             if (!opt.has_value()) {
-                ERROR("Cannot load file {} as CustomBeatmapLevelSaveData!", path.string());
+                ERROR("Cannot load file {} as CustomBeatmapLevelSaveDataV4!", path.string());
                 return nullptr;
             }
 
@@ -143,7 +144,7 @@ namespace SongCore::SongLoader {
         name = EmptyString(); \
     }
 
-    CustomBeatmapLevel* LevelLoader::LoadCustomBeatmapLevel(std::filesystem::path const& levelPath, bool wip, SongCore::CustomJSONData::CustomLevelInfoSaveData* saveData, std::string& hashOut) {
+    CustomBeatmapLevel* LevelLoader::LoadCustomBeatmapLevel(std::filesystem::path const& levelPath, bool wip, SongCore::CustomJSONData::CustomLevelInfoSaveDataV2* saveData, std::string& hashOut) {
         if (!saveData) {
             #ifdef THROW_ON_MISSING_DATA
             throw std::runtime_error(fmt::format("saveData was null for level @ {}", levelPath.string()));
@@ -241,21 +242,22 @@ namespace SongCore::SongLoader {
         return result;
     }
 
-    CustomBeatmapLevel* LevelLoader::LoadCustomBeatmapLevel(std::filesystem::path const& levelPath, bool wip, SongCore::CustomJSONData::CustomBeatmapLevelSaveData* saveData, std::string& hashOut) {
+    // LevelLoader.CreateBeatmapLevelFromV4
+    CustomBeatmapLevel* LevelLoader::LoadCustomBeatmapLevel(std::filesystem::path const& levelPath, bool wip, SongCore::CustomJSONData::CustomBeatmapLevelSaveDataV4* saveData, std::string& hashOut) {
         if (!saveData) {
+            WARNING("saveData was null for level @ {}", levelPath.string());
             #ifdef THROW_ON_MISSING_DATA
             throw std::runtime_error(fmt::format("saveData was null for level @ {}", levelPath.string()));
             #else
-            WARNING("saveData was null for level @ {}", levelPath.string());
             return nullptr;
             #endif
         }
 
         if (!BasicVerifyMap(levelPath, saveData)) {
+            WARNING("Map {} was missing files!", levelPath.string());
             #ifdef THROW_ON_MISSING_DATA
             throw std::runtime_error(fmt::format("Map {} was missing files!", levelPath.string()));
             #else
-            WARNING("Map {} was missing files!", levelPath);
             return nullptr;
             #endif
         }
@@ -319,7 +321,8 @@ namespace SongCore::SongLoader {
     }
 
 
-    std::pair<GlobalNamespace::FileSystemBeatmapLevelData*, LevelLoader::BeatmapBasicDataDict*> LevelLoader::GetBeatmapLevelAndBasicData(std::filesystem::path const& levelPath, std::string_view levelID, std::span<GlobalNamespace::EnvironmentName const> environmentNames, std::span<GlobalNamespace::ColorScheme* const> colorSchemes, CustomJSONData::CustomLevelInfoSaveData* saveData) {
+    // V2 | V3
+    std::pair<GlobalNamespace::FileSystemBeatmapLevelData*, LevelLoader::BeatmapBasicDataDict*> LevelLoader::GetBeatmapLevelAndBasicData(std::filesystem::path const& levelPath, std::string_view levelID, std::span<GlobalNamespace::EnvironmentName const> environmentNames, std::span<GlobalNamespace::ColorScheme* const> colorSchemes, CustomJSONData::CustomLevelInfoSaveDataV2* saveData) {
         auto fileDifficultyBeatmapsDict = System::Collections::Generic::Dictionary_2<CharacteristicDifficultyPair, GlobalNamespace::FileDifficultyBeatmap*>::New_ctor();
         auto basicDataDict = LevelLoader::BeatmapBasicDataDict::New_ctor();
         bool saveDataHadEnvNames = saveData->environmentNames.size() > 0;
@@ -409,7 +412,9 @@ namespace SongCore::SongLoader {
         };
     }
 
-    std::pair<GlobalNamespace::FileSystemBeatmapLevelData*, LevelLoader::BeatmapBasicDataDict*> LevelLoader::GetBeatmapLevelAndBasicData(std::filesystem::path const& levelPath, std::string_view levelID, CustomJSONData::CustomBeatmapLevelSaveData* saveData) {
+    // V4
+    // implementation of CustomLevelLoader.CreateBeatmapLevelDataFromV4
+    std::pair<GlobalNamespace::FileSystemBeatmapLevelData*, LevelLoader::BeatmapBasicDataDict*> LevelLoader::GetBeatmapLevelAndBasicData(std::filesystem::path const& levelPath, std::string_view levelID, CustomJSONData::CustomBeatmapLevelSaveDataV4* saveData) {
         auto fileDifficultyBeatmapsDict = System::Collections::Generic::Dictionary_2<CharacteristicDifficultyPair, GlobalNamespace::FileDifficultyBeatmap*>::New_ctor();
         auto basicDataDict = LevelLoader::BeatmapBasicDataDict::New_ctor();
 
@@ -472,10 +477,10 @@ namespace SongCore::SongLoader {
         for (auto diffBeatmap : saveData->difficultyBeatmaps) {
             auto characteristic = _beatmapCharacteristicCollection->GetBeatmapCharacteristicBySerializedName(diffBeatmap->characteristic);
             if (!characteristic) {
+                WARNING("Got null characteristic for characteristic name {}, skipping...", diffBeatmap->characteristic);
                 #ifdef THROW_ON_MISSING_DATA
                     throw std::runtime_error(fmt::format("Got null characteristic for characteristic name {}", diffBeatmap->characteristic));
                 #else
-                    WARNING("Got null characteristic for characteristic name {}, skipping...", diffBeatmap->characteristic);
                     continue;
                 #endif
             }
@@ -487,30 +492,30 @@ namespace SongCore::SongLoader {
             );
 
             if (!parseSuccess) {
+                WARNING("Failed to parse a diff string: {}, skipping...", diffBeatmap->difficulty);
                 #ifdef THROW_ON_MISSING_DATA
                     throw std::runtime_error(fmt::format("Failed to parse a diff string: {}", diffBeatmap->difficulty));
                 #else
-                    WARNING("Failed to parse a diff string: {}, skipping...", diffBeatmap->difficulty);
                     continue;
                 #endif
             }
 
             auto beatmapPath = levelPath / std::string(diffBeatmap->beatmapDataFilename);
             if (!std::filesystem::exists(beatmapPath)) {
+                WARNING("Diff file '{}' does not exist, skipping...", beatmapPath.string());
                 #ifdef THROW_ON_MISSING_DATA
                     throw std::runtime_error(fmt::format("Diff file '{}' does not exist", beatmapPath.string()));
                 #else
-                    WARNING("Diff file '{}' does not exist, skipping...", beatmapPath.string());
                     continue;
                 #endif
             }
 
             auto lightingPath = levelPath / std::string(diffBeatmap->lightshowDataFilename);
             if (!std::filesystem::exists(lightingPath)) {
+                WARNING("Diff Lighting file '{}' does not exist, skipping...", lightingPath.string());
                 #ifdef THROW_ON_MISSING_DATA
                     throw std::runtime_error(fmt::format("Diff Lighting file '{}' does not exist", lightingPath.string()));
                 #else
-                    WARNING("Diff Lighting file '{}' does not exist, skipping...", lightingPath.string());
                     continue;
                 #endif
             }
@@ -630,7 +635,7 @@ namespace SongCore::SongLoader {
         return colorSchemes->ToArray();
     }
 
-    float LevelLoader::GetLengthForLevel(std::filesystem::path const& levelPath, CustomJSONData::CustomLevelInfoSaveData* saveData) {
+    float LevelLoader::GetLengthForLevel(std::filesystem::path const& levelPath, CustomJSONData::CustomLevelInfoSaveDataV2* saveData) {
         // check the cached info
         auto cachedInfoOpt = Utils::GetCachedInfo(levelPath);
         if (cachedInfoOpt.has_value() && cachedInfoOpt->songDuration.has_value()) {
@@ -666,7 +671,7 @@ namespace SongCore::SongLoader {
         }
     }
 
-    float LevelLoader::GetLengthForLevel(std::filesystem::path const& levelPath, CustomJSONData::CustomBeatmapLevelSaveData* saveData) {
+    float LevelLoader::GetLengthForLevel(std::filesystem::path const& levelPath, CustomJSONData::CustomBeatmapLevelSaveDataV4* saveData) {
         // check the cached info
         auto cachedInfoOpt = Utils::GetCachedInfo(levelPath);
         if (cachedInfoOpt.has_value() && cachedInfoOpt->songDuration.has_value()) {
@@ -702,9 +707,9 @@ namespace SongCore::SongLoader {
         }
     }
 
-    float LevelLoader::GetLengthFromMap(std::filesystem::path const& levelPath, CustomJSONData::CustomLevelInfoSaveData* saveData) {
+    float LevelLoader::GetLengthFromMap(std::filesystem::path const& levelPath, CustomJSONData::CustomLevelInfoSaveDataV2* saveData) {
         try {
-            static auto GetFirstAvailableDiffFile = [](std::filesystem::path const& levelPath, CustomJSONData::CustomLevelInfoSaveData* saveData) -> GlobalNamespace::StandardLevelInfoSaveData::DifficultyBeatmap* {
+            static auto GetFirstAvailableDiffFile = [](std::filesystem::path const& levelPath, CustomJSONData::CustomLevelInfoSaveDataV2* saveData) -> GlobalNamespace::StandardLevelInfoSaveData::DifficultyBeatmap* {
                 for (auto set : saveData->difficultyBeatmapSets) {
                     auto beatmaps = set->difficultyBeatmaps;
                     for (auto itr = beatmaps.rbegin(); itr != beatmaps.rend(); itr ++) {
@@ -739,7 +744,9 @@ namespace SongCore::SongLoader {
                     auto beat = note->beat;
                     if (beat > highestBeat) highestBeat = beat;
                 }
-            } else if (beatmapSaveData->basicBeatmapEvents && beatmapSaveData->basicBeatmapEvents->Count > 0) {
+            }
+
+            if (beatmapSaveData->basicBeatmapEvents && beatmapSaveData->basicBeatmapEvents->Count > 0) {
                 for (auto event : ListW<::BeatmapSaveDataVersion3::BasicEventData*>(beatmapSaveData->basicBeatmapEvents)) {
                     auto beat = event->beat;
                     if (beat > highestBeat) highestBeat = beat;
@@ -759,9 +766,9 @@ namespace SongCore::SongLoader {
         return 0;
     }
 
-    float LevelLoader::GetLengthFromMap(std::filesystem::path const& levelPath, CustomJSONData::CustomBeatmapLevelSaveData* saveData) {
+    float LevelLoader::GetLengthFromMap(std::filesystem::path const& levelPath, CustomJSONData::CustomBeatmapLevelSaveDataV4* saveData) {
         try {
-            static auto GetFirstAvailableDiffFile = [](std::filesystem::path const& levelPath, CustomJSONData::CustomBeatmapLevelSaveData* saveData) -> BeatmapLevelSaveDataVersion4::BeatmapLevelSaveData::DifficultyBeatmap* {
+            static auto GetFirstAvailableDiffFile = [](std::filesystem::path const& levelPath, CustomJSONData::CustomBeatmapLevelSaveDataV4* saveData) -> BeatmapLevelSaveDataVersion4::BeatmapLevelSaveData::DifficultyBeatmap* {
                 for (auto beatmap : saveData->difficultyBeatmaps) {
                     std::string fileName(beatmap->beatmapDataFilename);
                     if (!fileName.empty() && std::filesystem::exists(levelPath / fileName)) {
@@ -823,7 +830,7 @@ namespace SongCore::SongLoader {
         return 0;
     }
 
-    bool LevelLoader::BasicVerifyMap(std::filesystem::path const& levelPath, CustomJSONData::CustomLevelInfoSaveData* saveData) {
+    bool LevelLoader::BasicVerifyMap(std::filesystem::path const& levelPath, CustomJSONData::CustomLevelInfoSaveDataV2* saveData) {
         std::string songFile(saveData->songFilename);
         std::string coverFile(saveData->coverImageFilename);
 
@@ -841,7 +848,7 @@ namespace SongCore::SongLoader {
         return true;
     }
 
-    bool LevelLoader::BasicVerifyMap(std::filesystem::path const& levelPath, CustomJSONData::CustomBeatmapLevelSaveData* saveData) {
+    bool LevelLoader::BasicVerifyMap(std::filesystem::path const& levelPath, CustomJSONData::CustomBeatmapLevelSaveDataV4* saveData) {
         std::string songFile(saveData->audio.songFilename);
         std::string coverFile(saveData->coverImageFilename);
         std::string audioFile(saveData->audio.audioDataFilename);
@@ -854,18 +861,19 @@ namespace SongCore::SongLoader {
         for (auto diff : saveData->difficultyBeatmaps) {
             std::string diffFile(diff->beatmapDataFilename);
             std::string lightFile(diff->lightshowDataFilename);
-            if (!std::filesystem::exists(levelPath / diffFile) || !std::filesystem::exists(levelPath / lightFile)) return false;
+            if (!std::filesystem::exists(levelPath / diffFile)) return false;
+            if (!std::filesystem::exists(levelPath / lightFile)) return false;
         }
 
         // no files were found to be missing, return success
         return true;
     }
 
-    SongCore::CustomJSONData::CustomLevelInfoSaveData* LevelLoader::LoadCustomSaveData(GlobalNamespace::StandardLevelInfoSaveData* saveData, std::u16string_view stringData) {
+    SongCore::CustomJSONData::CustomLevelInfoSaveDataV2* LevelLoader::LoadCustomSaveData(GlobalNamespace::StandardLevelInfoSaveData* saveData, std::u16string_view stringData) {
         auto customBeatmapSets = ArrayW<GlobalNamespace::StandardLevelInfoSaveData::DifficultyBeatmapSet*>(il2cpp_array_size_t(saveData->difficultyBeatmapSets.size()));
 
-        SongCore::CustomJSONData::CustomLevelInfoSaveData *customSaveData =
-                SongCore::CustomJSONData::CustomLevelInfoSaveData::New_ctor(
+        SongCore::CustomJSONData::CustomLevelInfoSaveDataV2 *customSaveData =
+                SongCore::CustomJSONData::CustomLevelInfoSaveDataV2::New_ctor(
                     saveData->songName,
                     saveData->songSubName,
                     saveData->songAuthorName,
@@ -947,7 +955,7 @@ namespace SongCore::SongLoader {
         return customSaveData;
     }
 
-    SongCore::CustomJSONData::CustomBeatmapLevelSaveData* LevelLoader::LoadCustomSaveData(BeatmapLevelSaveDataVersion4::BeatmapLevelSaveData* saveData, std::u16string_view stringData) {
+    SongCore::CustomJSONData::CustomBeatmapLevelSaveDataV4* LevelLoader::LoadCustomSaveData(BeatmapLevelSaveDataVersion4::BeatmapLevelSaveData* saveData, std::u16string_view stringData) {
         if (!saveData) {
             WARNING("Save Data is not valid!");
             return nullptr;
@@ -955,8 +963,8 @@ namespace SongCore::SongLoader {
 
         auto customDiffBeatmaps = ArrayW<BeatmapLevelSaveDataVersion4::BeatmapLevelSaveData::DifficultyBeatmap*>(il2cpp_array_size_t(saveData->difficultyBeatmaps.size()));
 
-        SongCore::CustomJSONData::CustomBeatmapLevelSaveData *customSaveData =
-                SongCore::CustomJSONData::CustomBeatmapLevelSaveData::New_ctor();
+        SongCore::CustomJSONData::CustomBeatmapLevelSaveDataV4 *customSaveData =
+                SongCore::CustomJSONData::CustomBeatmapLevelSaveDataV4::New_ctor();
         customSaveData->song = saveData->song;
         customSaveData->audio = saveData->audio;
         customSaveData->colorSchemes = saveData->colorSchemes;

--- a/src/SongLoader/LevelLoader.cpp
+++ b/src/SongLoader/LevelLoader.cpp
@@ -366,6 +366,7 @@ namespace SongCore::SongLoader {
                     difficulty
                 );
 
+                // This is v3 apparently so no need for a lightshow
                 fileDifficultyBeatmapsDict->Add(
                     dictKey,
                     GlobalNamespace::FileDifficultyBeatmap::New_ctor(
@@ -789,13 +790,15 @@ namespace SongCore::SongLoader {
             float highestBeat = 0.0f;
             if (beatmapSaveData->colorNotes && beatmapSaveData->colorNotes->get_Length() > 0) {
                 for (auto note : ListW<::BeatmapSaveDataVersion4::BeatmapBeatIndex*>(beatmapSaveData->colorNotes)) {
-                    auto beat = note->beat;
-                    if (beat > highestBeat) highestBeat = beat;
+                  auto beat = note->beat;
+                  highestBeat = std::max(beat, highestBeat);
+                  
                 }
-            } else if (lightshowSaveData->basicEvents && lightshowSaveData->basicEvents->get_Length() > 0) {
+            }
+            if (lightshowSaveData->basicEvents && lightshowSaveData->basicEvents->get_Length() > 0) {
                 for (auto event : ListW<::BeatmapSaveDataVersion4::BeatIndex*>(lightshowSaveData->basicEvents)) {
                     auto beat = event->beat;
-                    if (beat > highestBeat) highestBeat = beat;
+                    highestBeat = std::max(beat, highestBeat);
                 }
             }
 
@@ -854,7 +857,7 @@ namespace SongCore::SongLoader {
         return true;
     }
 
-    SongCore::CustomJSONData::CustomLevelInfoSaveData* LevelLoader::LoadCustomSaveData(GlobalNamespace::StandardLevelInfoSaveData* saveData, std::u16string const& stringData) {
+    SongCore::CustomJSONData::CustomLevelInfoSaveData* LevelLoader::LoadCustomSaveData(GlobalNamespace::StandardLevelInfoSaveData* saveData, std::u16string_view stringData) {
         auto customBeatmapSets = ArrayW<GlobalNamespace::StandardLevelInfoSaveData::DifficultyBeatmapSet*>(il2cpp_array_size_t(saveData->difficultyBeatmapSets.size()));
 
         SongCore::CustomJSONData::CustomLevelInfoSaveData *customSaveData =
@@ -885,7 +888,7 @@ namespace SongCore::SongLoader {
         customSaveData->_customSaveDataInfo->doc = sharedDoc;
 
         rapidjson::GenericDocument<rapidjson::UTF16<char16_t>> &doc = *sharedDoc;
-        doc.Parse(stringData.c_str());
+        doc.Parse(stringData.data());
 
         auto dataItr = doc.FindMember(u"_customData");
         if (dataItr != doc.MemberEnd()) {
@@ -940,7 +943,7 @@ namespace SongCore::SongLoader {
         return customSaveData;
     }
 
-    SongCore::CustomJSONData::CustomBeatmapLevelSaveData* LevelLoader::LoadCustomSaveData(BeatmapLevelSaveDataVersion4::BeatmapLevelSaveData* saveData, std::u16string const& stringData) {
+    SongCore::CustomJSONData::CustomBeatmapLevelSaveData* LevelLoader::LoadCustomSaveData(BeatmapLevelSaveDataVersion4::BeatmapLevelSaveData* saveData, std::u16string_view stringData) {
         if (!saveData) {
             WARNING("Save Data is not valid!");
             return nullptr;
@@ -959,7 +962,7 @@ namespace SongCore::SongLoader {
         customSaveData->environmentNames = saveData->environmentNames;
         customSaveData->version = saveData->version;
 
-        std::u16string str(stringData);
+        std::u16string_view str(stringData);
 
         auto sharedDoc = std::make_shared<SongCore::CustomJSONData::DocumentUTF16>();
         customSaveData->_customSaveDataInfo = SongCore::CustomJSONData::CustomSaveDataInfo();
@@ -967,7 +970,7 @@ namespace SongCore::SongLoader {
         customSaveData->_customSaveDataInfo->doc = sharedDoc;
 
         rapidjson::GenericDocument<rapidjson::UTF16<char16_t>> &doc = *sharedDoc;
-        doc.Parse(str.c_str());
+        doc.Parse(str.data());
 
         auto dataItr = doc.FindMember(u"customData");
         if (dataItr != doc.MemberEnd()) {

--- a/src/SongLoader/LevelLoader.cpp
+++ b/src/SongLoader/LevelLoader.cpp
@@ -413,11 +413,15 @@ namespace SongCore::SongLoader {
         auto fileDifficultyBeatmapsDict = System::Collections::Generic::Dictionary_2<CharacteristicDifficultyPair, GlobalNamespace::FileDifficultyBeatmap*>::New_ctor();
         auto basicDataDict = LevelLoader::BeatmapBasicDataDict::New_ctor();
 
-        auto environmentNames = ListW<GlobalNamespace::EnvironmentName>::New();
+        std::vector<GlobalNamespace::EnvironmentName> environmentNames;
+        INFO("Environments {}", fmt::join(saveData->environmentNames, ";"));
+
         for (StringW name : saveData->environmentNames) {
-            environmentNames->Add(
-                GetEnvironmentInfo(name, false)->_environmentName
+            environmentNames.emplace_back(
+                GetEnvironmentInfo(name, false)->serializedName
             );
+            INFO("Environment {}",
+                 GetEnvironmentInfo(name, false)->serializedName);
         }
 
         auto colorSchemes = ListW<GlobalNamespace::ColorScheme*>::New();

--- a/src/Utils/Hashing.cpp
+++ b/src/Utils/Hashing.cpp
@@ -12,7 +12,7 @@ using namespace GlobalNamespace;
 using namespace CryptoPP;
 
 namespace SongCore::Utils {
-    std::optional<std::string> GetCustomLevelHash(std::filesystem::path const& levelPath, SongCore::CustomJSONData::CustomLevelInfoSaveData* saveData) {
+    std::optional<std::string> GetCustomLevelHash(std::filesystem::path const& levelPath, SongCore::CustomJSONData::CustomLevelInfoSaveDataV2* saveData) {
         auto start = std::chrono::high_resolution_clock::now();
         std::string hashHex;
 
@@ -69,7 +69,7 @@ namespace SongCore::Utils {
         return hashHex;
     }
 
-    std::optional<std::string> GetCustomLevelHash(std::filesystem::path const& levelPath, SongCore::CustomJSONData::CustomBeatmapLevelSaveData* saveData) {
+    std::optional<std::string> GetCustomLevelHash(std::filesystem::path const& levelPath, SongCore::CustomJSONData::CustomBeatmapLevelSaveDataV4* saveData) {
         auto start = std::chrono::high_resolution_clock::now();
         std::string hashHex;
 


### PR DESCRIPTION
Resolves https://github.com/raineio/Quest-SongCore/issues/22

Practically uses the proper environment name the game expects internally.

[Should make this hook redundant](https://github.com/raineio/Quest-SongCore/blob/497513bc6fcc40e6de97ba3914573cdd7053821c/src/Hooks/SongLoadingHooks.cpp#L243-L265)