### PR TITLE
Implement partial songs refresh by song paths

### DIFF
--- a/shared/SongCore.hpp
+++ b/shared/SongCore.hpp
@@ -111,6 +111,10 @@ namespace SongCore::API {
         /// @return future you can use to check whether songs are done refreshing. if you want an onFinished see `GetSongsLoadedEvent`
         SONGCORE_EXPORT std::shared_future<void> RefreshSongs(bool fullRefresh = false);
 
+        /// @brief refresh the loaded songs in the songloader only in selected paths, if the songloader doesn't exist an invalid future is returned. the returned future can be ignored safely
+        /// @return future you can use to check whether songs are done refreshing
+        SONGCORE_EXPORT std::shared_future<void> RefreshSongsPaths(std::span<std::filesystem::path const> paths);
+
         /// @brief refresh the level packs, since this does not take long, it is not async
         SONGCORE_EXPORT void RefreshLevelPacks();
 

--- a/shared/SongLoader/RuntimeSongLoader.hpp
+++ b/shared/SongLoader/RuntimeSongLoader.hpp
@@ -57,6 +57,11 @@ DECLARE_CLASS_CODEGEN_INTERFACES(SongCore::SongLoader, RuntimeSongLoader, System
         /// @return shared future which you may await for when the songs are finished refreshing. if you want an onFinished use the `LevelsLoaded` event
         std::shared_future<void> RefreshSongs(bool fullRefresh = false);
 
+        /// @brief refreshes the loaded songs, loading any new ones from the provided paths
+        /// @param paths the paths to search for songs in
+        /// @return shared future which you may await for when the songs are finished refreshing. if you want an onFinished use the `LevelsLoaded` event
+        std::shared_future<void> RefreshSongsPaths(std::span<const std::filesystem::path> paths);
+
         /// @brief refreshes the level packs in the beatmaplevelsmodel
         void RefreshLevelPacks();
 
@@ -203,11 +208,17 @@ DECLARE_CLASS_CODEGEN_INTERFACES(SongCore::SongLoader, RuntimeSongLoader, System
         /// @brief collects levels from the roots into the given set, and keeps the wip status
         static void CollectLevels(std::span<const std::filesystem::path> roots, bool isWip, std::set<LevelPathAndWip>& out);
 
+        /// @brief collects levels from the paths into the given set, and keeps the wip status
+        static void CollectLevelsInPaths(std::span<const std::filesystem::path> paths, bool isWip, std::set<LevelPathAndWip>& out);
+
         /// @brief method used when a double (or triple, quadruple...) refresh is requested
         void RefreshRequestedWhileRefreshing();
 
         /// @brief method kicked of by RefreshSongs on an il2cpp async
         void RefreshSongs_internal(bool fullRefresh);
+
+        /// @brief method kicked of by RefreshSongsPaths on an il2cpp async
+        void RefreshSongsPaths_internal(std::span<const std::filesystem::path> paths);
 
         /// @brief worker thread for loading songs from a set
         void RefreshSongWorkerThread(std::mutex* levelsItrMutex, std::set<LevelPathAndWip>::const_iterator* levelsItr, std::set<LevelPathAndWip>::const_iterator* levelsEnd);

--- a/src/SongCore.cpp
+++ b/src/SongCore.cpp
@@ -207,6 +207,12 @@ namespace SongCore::API {
             return instance->RefreshSongs(fullRefresh);
         }
 
+        std::shared_future<void> RefreshSongsPaths(std::span<std::filesystem::path const> paths) {
+            auto instance = SongLoader::RuntimeSongLoader::get_instance();
+            if (!instance) return std::future<void>();
+            return instance->RefreshSongsPaths(paths);
+        }
+
         void RefreshLevelPacks() {
             auto instance = SongLoader::RuntimeSongLoader::get_instance();
             if (!instance) return;

--- a/src/SongLoader/RuntimeSongLoader.cpp
+++ b/src/SongLoader/RuntimeSongLoader.cpp
@@ -107,10 +107,8 @@ namespace SongCore::SongLoader {
     void RuntimeSongLoader::CollectLevelsInPaths(std::span<const std::filesystem::path> paths, bool isWip, std::set<LevelPathAndWip>& out) {
         // Grab levels from the given paths
         for (auto entry : paths) {
-            DEBUG("Collecting level in path {}", std::string(entry));
             std::filesystem::directory_entry dir(entry);
             if (!dir.is_directory()) continue;
-            DEBUG("Directory entry is a directory");
             auto songPath = dir.path();
             // if this is an autosaves dir, just skip silently
             if (songPath.string().ends_with("autosaves")) continue;
@@ -168,10 +166,6 @@ namespace SongCore::SongLoader {
     std::shared_future<void> RuntimeSongLoader::RefreshSongsPaths(std::span<const std::filesystem::path> paths) {
         bool fullRefresh = false;
 
-        for (auto entry : paths) {
-            DEBUG("Checking path before future {}", std::string(entry));
-        }
-
 
         if (AreSongsRefreshing) {
             INFO("Refresh was requested while songs were refreshing, queueing up a new refresh for afterwards, or returning the already queued up refresh");
@@ -205,9 +199,6 @@ namespace SongCore::SongLoader {
 
 
     void RuntimeSongLoader::RefreshSongsPaths_internal(std::span<const std::filesystem::path> paths) {
-        for (auto entry : paths) {
-            DEBUG("Checking path in future {}", std::string(entry));
-        }
         InvokeSongsWillRefresh();
         auto refreshStartTime = high_resolution_clock::now();
 


### PR DESCRIPTION
This feature should help us with much faster song refresh times when users have many songs by only loading the songs that the downloading tool passes to the function