### PR TITLE
Removed legacy BPM events support

### DIFF
--- a/src/Hooks/YeetLegacyBPMEventsHook.cpp
+++ b/src/Hooks/YeetLegacyBPMEventsHook.cpp
@@ -1,0 +1,38 @@
+#include "hooking.hpp"
+#include "logging.hpp"
+
+#include "BeatmapSaveDataVersion2_6_0AndEarlier/BeatmapSaveDataVersion2_6_0AndEarlier.hpp"
+
+#include "System/Collections/Generic/IReadOnlyCollection_1.hpp"
+
+// Event10 was briefly used as an official BPM change between 1.8.0 and 1.18.0,
+// but it was never supported by custom mapping tools and later reused as a light event.
+// The code to convert these events broke a lot of maps, so we are removing it here.
+MAKE_AUTO_HOOK_MATCH(
+    BeatmapSaveData_ConvertBeatmapSaveDataPreV2_5_0Inline,
+    &BeatmapSaveDataVersion2_6_0AndEarlier::BeatmapSaveData::ConvertBeatmapSaveDataPreV2_5_0Inline,
+    void,
+    BeatmapSaveDataVersion2_6_0AndEarlier::BeatmapSaveData *self)
+{
+    // Use fake type to avoid conversion logic and to keep the original call so it can be hooked by other mods
+    const BeatmapSaveDataCommon::BeatmapEventType placeholderType = 999;
+    for (int i = 0; i < ((System::Collections::Generic::IReadOnlyCollection_1<BeatmapSaveDataVersion2_6_0AndEarlier::EventData *> *)self->events)->Count; i++)
+    {
+        auto event = self->events->Item[i];
+        if (event->_type == BeatmapSaveDataCommon::BeatmapEventType::LegacyBpmEventType)
+        {
+            event->_type = placeholderType;
+        }
+    }
+
+    BeatmapSaveData_ConvertBeatmapSaveDataPreV2_5_0Inline(self);
+
+    for (int i = 0; i < ((System::Collections::Generic::IReadOnlyCollection_1<BeatmapSaveDataVersion2_6_0AndEarlier::EventData *> *)self->_events)->Count; i++)
+    {
+        auto event = self->_events->Item[i];
+        if (event->_type == placeholderType)
+        {
+            event->_type = BeatmapSaveDataCommon::BeatmapEventType::LegacyBpmEventType;
+        }
+    }
+}


### PR DESCRIPTION
Port of: https://github.com/Kylemc1413/SongCore/pull/149

Event with a type 10 was introduced as an official BPM change event in 1.8.0 and later reused as a light in 1.18.0. This change disables the conversion of legacy BPM changes to add support for maps with type 10 events as lights, but with a wrong map version.

From the collection of 170k recently (last 2 years) played maps, there were 226 broken maps because of the conversion. Some are quite popular, and 2 ranked maps (1 on BL and 1 on SS). And not a single map that properly utilized these events as BPM changes.
Popular mapping tools (MM/custom saber/CM) never had support for this event, and mappers who tried to use them manually were complaining, so I couldn't even find an example map, let alone a map anyone plays.

Tested on: https://beatsaver.com/maps/2b629