### PR TITLE
Fix cache not loading

### DIFF
--- a/src/Hooks/SongLoadingHooks.cpp
+++ b/src/Hooks/SongLoadingHooks.cpp
@@ -195,7 +195,7 @@ MAKE_AUTO_HOOK_ORIG_MATCH(FileHelpers_GetEscapedURLForFilePath, &FileHelpers::Ge
 
 // get the level data async
 // TODO: rip out this level data loading from the SongLoader/LevelLoader.cpp and implement it async here to improve level loading speed and not do redundant things here
-MAKE_AUTO_HOOK_ORIG_MATCH(BeatmapLevelsModel_LoadBeatmapLevelDataAsync, &BeatmapLevelLoader::LoadBeatmapLevelDataAsync, Task_1<LoadBeatmapLevelDataResult>*, BeatmapLevelLoader* self, BeatmapLevel* beatmapLevel, GlobalNamespace::BeatmapLevelDataVersion beatmapLevelDataVersion, CancellationToken token) {
+MAKE_AUTO_HOOK_ORIG_MATCH(BeatmapLevelLoader_LoadBeatmapLevelDataAsync, &BeatmapLevelLoader::LoadBeatmapLevelDataAsync, Task_1<LoadBeatmapLevelDataResult>*, BeatmapLevelLoader* self, BeatmapLevel* beatmapLevel, GlobalNamespace::BeatmapLevelDataVersion beatmapLevelDataVersion, CancellationToken token) {
     if (beatmapLevel->levelID.starts_with(u"custom_level_")) {
         IBeatmapLevelData* beatmapLevelData;
         if(self->_loadedBeatmapLevelDataCache->TryGetFromCache(beatmapLevel->levelID, byref(beatmapLevelData))) {
@@ -213,7 +213,7 @@ MAKE_AUTO_HOOK_ORIG_MATCH(BeatmapLevelsModel_LoadBeatmapLevelDataAsync, &Beatmap
             return LoadBeatmapLevelDataResult::Success(data);
         }, std::forward<SongCore::CancellationToken>(token));
     }
-    return BeatmapLevelsModel_LoadBeatmapLevelDataAsync(self, beatmapLevel, beatmapLevelDataVersion, token);
+    return BeatmapLevelLoader_LoadBeatmapLevelDataAsync(self, beatmapLevel, beatmapLevelDataVersion, token);
 }
 
 // get the level data async

--- a/src/Hooks/SongLoadingHooks.cpp
+++ b/src/Hooks/SongLoadingHooks.cpp
@@ -216,6 +216,23 @@ MAKE_AUTO_HOOK_ORIG_MATCH(BeatmapLevelLoader_LoadBeatmapLevelDataAsync, &Beatmap
     return BeatmapLevelLoader_LoadBeatmapLevelDataAsync(self, beatmapLevel, beatmapLevelDataVersion, token);
 }
 
+MAKE_AUTO_HOOK_ORIG_MATCH(BeatmapLevelsModel_LoadBeatmapLevelDataAsync, &BeatmapLevelsModel::LoadBeatmapLevelDataAsync, Task_1<LoadBeatmapLevelDataResult>*, BeatmapLevelsModel* self, StringW levelID, GlobalNamespace::BeatmapLevelDataVersion beatmapLevelDataVersion, CancellationToken token) {
+    if (levelID.starts_with(u"custom_level_")) {
+        return SongCore::StartTask<LoadBeatmapLevelDataResult>([=](SongCore::CancellationToken token){
+            auto errorType = System::Nullable_1(true, LoadBeatmapLevelDataResult_ErrorType::BeatmapLevelNotFoundInRepository);
+            static auto Error = LoadBeatmapLevelDataResult(errorType, nullptr);
+            auto level = SongCore::API::Loading::GetLevelByLevelID(static_cast<std::string>(levelID));
+            if (!level || token.IsCancellationRequested) return Error;
+            auto data = level->beatmapLevelData;
+            if (!data) return Error;
+
+
+            return LoadBeatmapLevelDataResult::Success(data);
+        }, std::forward<SongCore::CancellationToken>(token));
+    }
+    return BeatmapLevelsModel_LoadBeatmapLevelDataAsync(self, levelID, beatmapLevelDataVersion, token);
+}
+
 // get the level data async
 // TODO: rip out this level data loading from the SongLoader/LevelLoader.cpp and implement it async here to improve level loading speed and not do redundant things here
 MAKE_AUTO_HOOK_ORIG_MATCH(BeatmapLevelsModel_CheckBeatmapLevelDataExistsAsync, &BeatmapLevelsModel::CheckBeatmapLevelDataExistsAsync, Task_1<bool>*, BeatmapLevelsModel* self, StringW levelID, GlobalNamespace::BeatmapLevelDataVersion beatmapLevelDataVersion, CancellationToken token) {


### PR DESCRIPTION
When first starting up the game on latest version, the cache does not load properly causing maps to be unloaded until a refresh start of songs.